### PR TITLE
Migrate to Swift 3.0

### DIFF
--- a/SwCrypt.xcodeproj/project.pbxproj
+++ b/SwCrypt.xcodeproj/project.pbxproj
@@ -153,9 +153,11 @@
 				TargetAttributes = {
 					A0A71E771CBC7D74002C5C88 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0800;
 					};
 					A0A71E811CBC7D74002C5C88 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -328,6 +330,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -345,6 +348,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = hu.irl.SwCrypt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -355,6 +359,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = hu.irl.SwCryptTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -365,6 +370,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = hu.irl.SwCryptTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SwCrypt/SwCrypt.swift
+++ b/SwCrypt/SwCrypt.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public class SwKeyStore {
+open class SwKeyStore {
 
-	public enum SecError: OSStatus, ErrorType {
+	public enum SecError: OSStatus, Error {
 		case unimplemented = -4
 		case param = -50
 		case allocate = -108
@@ -29,135 +29,135 @@ public class SwKeyStore {
 		}
 	}
 
-	public static func upsertKey(pemKey: String, keyTag: String,
+	open static func upsertKey(_ pemKey: String, keyTag: String,
 	                             options: [NSString : AnyObject] = [:]) throws {
-		let pemKeyAsData = pemKey.dataUsingEncoding(NSUTF8StringEncoding)!
+		let pemKeyAsData = pemKey.data(using: String.Encoding.utf8)!
 
 		var parameters: [NSString : AnyObject] = [
 			kSecClass: kSecClassKey,
 			kSecAttrKeyType: kSecAttrKeyTypeRSA,
-			kSecAttrIsPermanent: true,
-			kSecAttrApplicationTag: keyTag,
-			kSecValueData: pemKeyAsData
+			kSecAttrIsPermanent: true as AnyObject,
+			kSecAttrApplicationTag: keyTag as AnyObject,
+			kSecValueData: pemKeyAsData as AnyObject
 		]
 		options.forEach { k, v in
 			parameters[k] = v
 		}
 
-		var status = SecItemAdd(parameters, nil)
+		var status = SecItemAdd(parameters as CFDictionary, nil)
 		if status == errSecDuplicateItem {
 			try delKey(keyTag)
-			status = SecItemAdd(parameters, nil)
+			status = SecItemAdd(parameters as CFDictionary, nil)
 		}
 		guard status == errSecSuccess else { throw SecError(status) }
 	}
 
-	public static func getKey(keyTag: String) throws -> String {
+	open static func getKey(_ keyTag: String) throws -> String {
 		let parameters: [NSString : AnyObject] = [
 			kSecClass : kSecClassKey,
 			kSecAttrKeyType : kSecAttrKeyTypeRSA,
-			kSecAttrApplicationTag : keyTag,
-			kSecReturnData : true
+			kSecAttrApplicationTag : keyTag as AnyObject,
+			kSecReturnData : true as AnyObject
 		]
 		var data: AnyObject?
-		let status = SecItemCopyMatching(parameters, &data)
+		let status = SecItemCopyMatching(parameters as CFDictionary, &data)
 		guard status == errSecSuccess else { throw SecError(status) }
 
-		guard let pemKeyAsData = data as? NSData else {
+		guard let pemKeyAsData = data as? Data else {
 			throw SecError(.decode)
 		}
-		guard let result = String(data: pemKeyAsData, encoding: NSUTF8StringEncoding) else {
+		guard let result = String(data: pemKeyAsData, encoding: String.Encoding.utf8) else {
 			throw SecError(.decode)
 		}
 		return result
 	}
 
-	public static func delKey(keyTag: String) throws {
+	open static func delKey(_ keyTag: String) throws {
 		let parameters: [NSString : AnyObject] = [
 			kSecClass : kSecClassKey,
-			kSecAttrApplicationTag: keyTag
+			kSecAttrApplicationTag: keyTag as AnyObject
 		]
-		let status = SecItemDelete(parameters)
+		let status = SecItemDelete(parameters as CFDictionary)
 		guard status == errSecSuccess else { throw SecError(status) }
 	}
 }
 
-public class SwKeyConvert {
+open class SwKeyConvert {
 
-	public enum Error: ErrorType {
+	public enum SwError: Error {
 		case invalidKey
 		case badPassphrase
 		case keyNotEncrypted
 
 		public static var debugLevel = 1
 
-		init(_ type: Error, function: String = #function, file: String = #file, line: Int = #line) {
+		init(_ type: SwError, function: String = #function, file: String = #file, line: Int = #line) {
 			self = type
-			if Error.debugLevel > 0 {
+			if SwError.debugLevel > 0 {
 				print("\(file):\(line): [\(function)] \(self._domain): \(self)")
 			}
 		}
 	}
 
-	public class PrivateKey {
+	open class PrivateKey {
 
-		public static func pemToPKCS1DER(pemKey: String) throws -> NSData {
+		open static func pemToPKCS1DER(_ pemKey: String) throws -> Data {
 			guard let derKey = try? PEM.PrivateKey.toDER(pemKey) else {
-				throw Error(.invalidKey)
+				throw SwError(.invalidKey)
 			}
 			guard let pkcs1DERKey = PKCS8.PrivateKey.stripHeaderIfAny(derKey) else {
-				throw Error(.invalidKey)
+				throw SwError(.invalidKey)
 			}
 			return pkcs1DERKey
 		}
 
-		public static func derToPKCS1PEM(derKey: NSData) -> String {
+		open static func derToPKCS1PEM(_ derKey: Data) -> String {
 			return PEM.PrivateKey.toPEM(derKey)
 		}
 
 		public typealias EncMode = PEM.EncryptedPrivateKey.EncMode
 
-		public static func encryptPEM(pemKey: String, passphrase: String,
+		open static func encryptPEM(_ pemKey: String, passphrase: String,
 		                              mode: EncMode) throws -> String {
 			do {
 				let derKey = try PEM.PrivateKey.toDER(pemKey)
 				return PEM.EncryptedPrivateKey.toPEM(derKey, passphrase: passphrase, mode: mode)
 			} catch {
-				throw Error(.invalidKey)
+				throw SwError(.invalidKey)
 			}
 		}
 
-		public static func decryptPEM(pemKey: String, passphrase: String) throws -> String {
+		open static func decryptPEM(_ pemKey: String, passphrase: String) throws -> String {
 			do {
 				let derKey = try PEM.EncryptedPrivateKey.toDER(pemKey, passphrase: passphrase)
 				return PEM.PrivateKey.toPEM(derKey)
-			} catch PEM.Error.badPassphrase {
-				throw Error(.badPassphrase)
-			} catch PEM.Error.keyNotEncrypted {
-				throw Error(.keyNotEncrypted)
+			} catch PEM.SwError.badPassphrase {
+				throw SwError(.badPassphrase)
+			} catch PEM.SwError.keyNotEncrypted {
+				throw SwError(.keyNotEncrypted)
 			} catch {
-				throw Error(.invalidKey)
+				throw SwError(.invalidKey)
 			}
 		}
 	}
 
-	public class PublicKey {
+	open class PublicKey {
 
-		public static func pemToPKCS1DER(pemKey: String) throws -> NSData {
+		open static func pemToPKCS1DER(_ pemKey: String) throws -> Data {
 			guard let derKey = try? PEM.PublicKey.toDER(pemKey) else {
-				throw Error(.invalidKey)
+				throw SwError(.invalidKey)
 			}
 			guard let pkcs1DERKey = PKCS8.PublicKey.stripHeaderIfAny(derKey) else {
-				throw Error(.invalidKey)
+				throw SwError(.invalidKey)
 			}
 			return pkcs1DERKey
 		}
 
-		public static func derToPKCS1PEM(derKey: NSData) -> String {
+		open static func derToPKCS1PEM(_ derKey: Data) -> String {
 			return PEM.PublicKey.toPEM(derKey)
 		}
 
-		public static func derToPKCS8PEM(derKey: NSData) -> String {
+		open static func derToPKCS8PEM(_ derKey: Data) -> String {
 			let pkcs8Key = PKCS8.PublicKey.addHeader(derKey)
 			return PEM.PublicKey.toPEM(pkcs8Key)
 		}
@@ -166,12 +166,12 @@ public class SwKeyConvert {
 
 }
 
-public class PKCS8 {
+open class PKCS8 {
 
-	public class PrivateKey {
+	open class PrivateKey {
 
 		//https://lapo.it/asn1js/
-		public static func getPKCS1DEROffset(derKey: NSData) -> Int? {
+		open static func getPKCS1DEROffset(_ derKey: Data) -> Int? {
 			let bytes = derKey.bytesView
 
 			var offset = 0
@@ -224,25 +224,25 @@ public class PKCS8 {
 			return offset
 		}
 
-		public static func stripHeaderIfAny(derKey: NSData) -> NSData? {
+		open static func stripHeaderIfAny(_ derKey: Data) -> Data? {
 			guard let offset = getPKCS1DEROffset(derKey) else {
 				return nil
 			}
-			return derKey.subdataWithRange(NSRange(location: offset, length: derKey.length - offset))
+			return derKey.subdata(in: offset..<derKey.count)
 		}
 
-		public static func hasCorrectHeader(derKey: NSData) -> Bool {
+		open static func hasCorrectHeader(_ derKey: Data) -> Bool {
 			return getPKCS1DEROffset(derKey) != nil
 		}
 
 	}
 
-	public class PublicKey {
+	open class PublicKey {
 
-		public static func addHeader(derKey: NSData) -> NSData {
-			let result = NSMutableData()
+		open static func addHeader(_ derKey: Data) -> Data {
+			var result = Data()
 
-			let encodingLength: Int = encodedOctets(derKey.length + 1).count
+			let encodingLength: Int = encodedOctets(derKey.count + 1).count
 			let OID: [UInt8] = [0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
 			                    0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00]
 
@@ -252,26 +252,26 @@ public class PKCS8 {
 			builder.append(0x30)
 
 			// Overall size, made of OID + bitstring encoding + actual key
-			let size = OID.count + 2 + encodingLength + derKey.length
+			let size = OID.count + 2 + encodingLength + derKey.count
 			let encodedSize = encodedOctets(size)
-			builder.appendContentsOf(encodedSize)
-			result.appendBytes(builder, length: builder.count)
-			result.appendBytes(OID, length: OID.count)
-			builder.removeAll(keepCapacity: false)
+			builder.append(contentsOf: encodedSize)
+			result.append(builder, count: builder.count)
+			result.append(OID, count: OID.count)
+			builder.removeAll(keepingCapacity: false)
 
 			builder.append(0x03)
-			builder.appendContentsOf(encodedOctets(derKey.length + 1))
+			builder.append(contentsOf: encodedOctets(derKey.count + 1))
 			builder.append(0x00)
-			result.appendBytes(builder, length: builder.count)
+			result.append(builder, count: builder.count)
 
 			// Actual key bytes
-			result.appendData(derKey)
+			result.append(derKey)
 
-			return result as NSData
+			return result
 		}
 
 		//https://lapo.it/asn1js/
-		public static func getPKCS1DEROffset(derKey: NSData) -> Int? {
+		open static func getPKCS1DEROffset(_ derKey: Data) -> Int? {
 			let bytes = derKey.bytesView
 
 			var offset = 0
@@ -323,18 +323,18 @@ public class PKCS8 {
 			return offset
 		}
 
-		public static func stripHeaderIfAny(derKey: NSData) -> NSData? {
+		open static func stripHeaderIfAny(_ derKey: Data) -> Data? {
 			guard let offset = getPKCS1DEROffset(derKey) else {
 				return nil
 			}
-			return derKey.subdataWithRange(NSRange(location: offset, length: derKey.length - offset))
+			return derKey.subdata(in: offset..<derKey.count)
 		}
 
-		public static func hasCorrectHeader(derKey: NSData) -> Bool {
+		open static func hasCorrectHeader(_ derKey: Data) -> Bool {
 			return getPKCS1DEROffset(derKey) != nil
 		}
 
-		private static func encodedOctets(int: Int) -> [UInt8] {
+		fileprivate static func encodedOctets(_ int: Int) -> [UInt8] {
 			// Short form
 			if int < 128 {
 				return [UInt8(int)]
@@ -346,7 +346,7 @@ public class PKCS8 {
 			var result: [UInt8] = [UInt8(i + 0x80)]
 
 			for _ in 0..<i {
-				result.insert(UInt8(len & 0xFF), atIndex: 1)
+				result.insert(UInt8(len & 0xFF), at: 1)
 				len = len >> 8
 			}
 
@@ -355,119 +355,120 @@ public class PKCS8 {
 	}
 }
 
-public class PEM {
+open class PEM {
 
-	public enum Error: ErrorType {
+	public enum SwError: Error {
 		case parse(String)
 		case badPassphrase
 		case keyNotEncrypted
 
 		public static var debugLevel = 1
 
-		init(_ type: Error, function: String = #function, file: String = #file, line: Int = #line) {
+		init(_ type: SwError, function: String = #function, file: String = #file, line: Int = #line) {
 			self = type
-			if Error.debugLevel > 0 {
+			if SwError.debugLevel > 0 {
 				print("\(file):\(line): [\(function)] \(self._domain): \(self)")
 			}
 		}
 	}
 
-	public class PrivateKey {
+	open class PrivateKey {
 
-		public static func toDER(pemKey: String) throws -> NSData {
+		open static func toDER(_ pemKey: String) throws -> Data {
 			guard let strippedKey = stripHeader(pemKey) else {
-				throw Error(.parse("header"))
+				throw SwError(.parse("header"))
 			}
 			guard let data = PEM.base64Decode(strippedKey) else {
-				throw Error(.parse("base64decode"))
+				throw SwError(.parse("base64decode"))
 			}
 			return data
 		}
 
-		public static func toPEM(derKey: NSData) -> String {
+		open static func toPEM(_ derKey: Data) -> String {
 			let base64 = PEM.base64Encode(derKey)
 			return addRSAHeader(base64)
 		}
 
-		private static let prefix = "-----BEGIN PRIVATE KEY-----\n"
-		private static let suffix = "\n-----END PRIVATE KEY-----"
-		private static let rsaPrefix = "-----BEGIN RSA PRIVATE KEY-----\n"
-		private static let rsaSuffix = "\n-----END RSA PRIVATE KEY-----"
+		fileprivate static let prefix = "-----BEGIN PRIVATE KEY-----\n"
+		fileprivate static let suffix = "\n-----END PRIVATE KEY-----"
+		fileprivate static let rsaPrefix = "-----BEGIN RSA PRIVATE KEY-----\n"
+		fileprivate static let rsaSuffix = "\n-----END RSA PRIVATE KEY-----"
 
-		private static func addHeader(base64: String) -> String {
+		fileprivate static func addHeader(_ base64: String) -> String {
 			return prefix + base64 + suffix
 		}
 
-		private static func addRSAHeader(base64: String) -> String {
+		fileprivate static func addRSAHeader(_ base64: String) -> String {
 			return rsaPrefix + base64 + rsaSuffix
 		}
 
-		private static func stripHeader(pemKey: String) -> String? {
+		fileprivate static func stripHeader(_ pemKey: String) -> String? {
 			return PEM.stripHeaderFooter(pemKey, header: prefix, footer: suffix) ??
 				PEM.stripHeaderFooter(pemKey, header: rsaPrefix, footer: rsaSuffix)
 		}
 	}
 
-	public class PublicKey {
+	open class PublicKey {
 
-		public static func toDER(pemKey: String) throws -> NSData {
+		open static func toDER(_ pemKey: String) throws -> Data {
 			guard let strippedKey = stripHeader(pemKey) else {
-				throw Error(.parse("header"))
+				throw SwError(.parse("header"))
 			}
 			guard let data = PEM.base64Decode(strippedKey) else {
-				throw Error(.parse("base64decode"))
+				throw SwError(.parse("base64decode"))
 			}
 			return data
 		}
 
-		public static func toPEM(derKey: NSData) -> String {
+		open static func toPEM(_ derKey: Data) -> String {
 			let base64 = PEM.base64Encode(derKey)
 			return addHeader(base64)
 		}
 
-		private static let pemPrefix = "-----BEGIN PUBLIC KEY-----\n"
-		private static let pemSuffix = "\n-----END PUBLIC KEY-----"
+		fileprivate static let pemPrefix = "-----BEGIN PUBLIC KEY-----\n"
+		fileprivate static let pemSuffix = "\n-----END PUBLIC KEY-----"
 
-		private static func addHeader(base64: String) -> String {
+		fileprivate static func addHeader(_ base64: String) -> String {
 			return pemPrefix + base64 + pemSuffix
 		}
 
-		private static func stripHeader(pemKey: String) -> String? {
+		fileprivate static func stripHeader(_ pemKey: String) -> String? {
 			return PEM.stripHeaderFooter(pemKey, header: pemPrefix, footer: pemSuffix)
 		}
 	}
 
-	public class EncryptedPrivateKey {
+	open class EncryptedPrivateKey {
 
 		public enum EncMode {
 			case aes128CBC, aes256CBC
 		}
 
-		public static func toDER(pemKey: String, passphrase: String) throws -> NSData {
+		open static func toDER(_ pemKey: String, passphrase: String) throws -> Data {
 			guard let strippedKey = PrivateKey.stripHeader(pemKey) else {
-				throw Error(.parse("header"))
+				throw SwError(.parse("header"))
 			}
 			guard let mode = getEncMode(strippedKey) else {
-				throw Error(.keyNotEncrypted)
+				throw SwError(.keyNotEncrypted)
 			}
 			guard let iv = getIV(strippedKey) else {
-				throw Error(.parse("iv"))
+				throw SwError(.parse("iv"))
 			}
 			let aesKey = getAESKey(mode, passphrase: passphrase, iv: iv)
-			let base64Data = strippedKey.substringFromIndex(strippedKey.startIndex + aesHeaderLength)
+            let base64Data = strippedKey.substring(
+                from: strippedKey.index(strippedKey.startIndex, offsetBy:aesHeaderLength))
 			guard let data = PEM.base64Decode(base64Data) else {
-				throw Error(.parse("base64decode"))
+				throw SwError(.parse("base64decode"))
 			}
 			guard let decrypted = try? decryptKey(data, key: aesKey, iv: iv) else {
-				throw Error(.badPassphrase)
+				throw SwError(.badPassphrase)
 			}
 			guard PKCS8.PrivateKey.hasCorrectHeader(decrypted) else {
-				throw Error(.badPassphrase)
+				throw SwError(.badPassphrase)
 			}
 			return decrypted
 		}
 
-		public static func toPEM(derKey: NSData, passphrase: String, mode: EncMode) -> String {
+		open static func toPEM(_ derKey: Data, passphrase: String, mode: EncMode) -> String {
 			let iv = CC.generateRandom(16)
 			let aesKey = getAESKey(mode, passphrase: passphrase, iv: iv)
 			let encrypted = encryptKey(derKey, key: aesKey, iv: iv)
@@ -475,24 +476,24 @@ public class PEM {
 			return PrivateKey.addRSAHeader(encryptedDERKey)
 		}
 
-		private static let aes128CBCInfo = "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,"
-		private static let aes256CBCInfo = "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,"
-		private static let aesInfoLength = aes128CBCInfo.characters.count
-		private static let aesIVInHexLength = 32
-		private static let aesHeaderLength = aesInfoLength + aesIVInHexLength
+		fileprivate static let aes128CBCInfo = "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,"
+		fileprivate static let aes256CBCInfo = "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,"
+		fileprivate static let aesInfoLength = aes128CBCInfo.characters.count
+		fileprivate static let aesIVInHexLength = 32
+		fileprivate static let aesHeaderLength = aesInfoLength + aesIVInHexLength
 
-		private static func addEncryptHeader(key: NSData, iv: NSData, mode: EncMode) -> String {
+		fileprivate static func addEncryptHeader(_ key: Data, iv: Data, mode: EncMode) -> String {
 			return getHeader(mode) + iv.hexadecimalString() + "\n\n" + PEM.base64Encode(key)
 		}
 
-		private static func getHeader(mode: EncMode) -> String {
+		fileprivate static func getHeader(_ mode: EncMode) -> String {
 			switch mode {
 			case .aes128CBC: return aes128CBCInfo
 			case .aes256CBC: return aes256CBCInfo
 			}
 		}
 
-		private static func getEncMode(strippedKey: String) -> EncMode? {
+		fileprivate static func getEncMode(_ strippedKey: String) -> EncMode? {
 			if strippedKey.hasPrefix(aes128CBCInfo) {
 				return .aes128CBC
 			}
@@ -502,55 +503,57 @@ public class PEM {
 			return nil
 		}
 
-		private static func getIV(strippedKey: String) -> NSData? {
-			let ivInHex = strippedKey.substringWithRange(
-				strippedKey.startIndex + aesInfoLength ..< strippedKey.startIndex + aesHeaderLength)
+		fileprivate static func getIV(_ strippedKey: String) -> Data? {
+			let ivInHex = strippedKey.substring(
+				with: strippedKey.index(strippedKey.startIndex,
+				                        offsetBy:aesInfoLength) ..< strippedKey.index(strippedKey.startIndex,
+				                                                                      offsetBy:aesHeaderLength))
 			return ivInHex.dataFromHexadecimalString()
 		}
 
-		private static func getAESKey(mode: EncMode, passphrase: String, iv: NSData) -> NSData {
+		fileprivate static func getAESKey(_ mode: EncMode, passphrase: String, iv: Data) -> Data {
 			switch mode {
 			case .aes128CBC: return getAES128Key(passphrase, iv: iv)
 			case .aes256CBC: return getAES256Key(passphrase, iv: iv)
 			}
 		}
 
-		private static func getAES128Key(passphrase: String, iv: NSData) -> NSData {
+		fileprivate static func getAES128Key(_ passphrase: String, iv: Data) -> Data {
 			//128bit_Key = MD5(Passphrase + Salt)
-			let pass = passphrase.dataUsingEncoding(NSUTF8StringEncoding)!
-			let salt = iv.subdataWithRange(NSRange(location: 0, length: 8))
+			let pass = passphrase.data(using: String.Encoding.utf8)!
+			let salt = iv.subdata(in: 0..<8)
 
-			let key = NSMutableData(data: pass)
-			key.appendData(salt)
+			var key = pass
+			key.append(salt)
 			return CC.digest(key, alg: .md5)
 		}
 
-		private static func getAES256Key(passphrase: String, iv: NSData) -> NSData {
+		fileprivate static func getAES256Key(_ passphrase: String, iv: Data) -> Data {
 			//128bit_Key = MD5(Passphrase + Salt)
 			//256bit_Key = 128bit_Key + MD5(128bit_Key + Passphrase + Salt)
-			let pass = passphrase.dataUsingEncoding(NSUTF8StringEncoding)!
-			let salt = iv.subdataWithRange(NSRange(location: 0, length: 8))
+			let pass = passphrase.data(using: String.Encoding.utf8)!
+			let salt = iv.subdata(in: 0 ..< 8)
 
-			let first = NSMutableData(data: pass)
-			first.appendData(salt)
+			var first = pass
+			first.append(salt)
 			let aes128Key = CC.digest(first, alg: .md5)
 
-			let sec = NSMutableData(data: aes128Key)
-			sec.appendData(pass)
-			sec.appendData(salt)
+			var sec = aes128Key
+			sec.append(pass)
+			sec.append(salt)
 
-			let aes256Key = NSMutableData(data: aes128Key)
-			aes256Key.appendData(CC.digest(sec, alg: .md5))
+			var aes256Key = aes128Key
+			aes256Key.append(CC.digest(sec, alg: .md5))
 			return aes256Key
 		}
 
-		private static func encryptKey(data: NSData, key: NSData, iv: NSData) -> NSData {
+		fileprivate static func encryptKey(_ data: Data, key: Data, iv: Data) -> Data {
 			return try! CC.crypt(
 				.encrypt, blockMode: .cbc, algorithm: .aes, padding: .pkcs7Padding,
 				data: data, key: key, iv: iv)
 		}
 
-		private static func decryptKey(data: NSData, key: NSData, iv: NSData) throws -> NSData {
+		fileprivate static func decryptKey(_ data: Data, key: Data, iv: Data) throws -> Data {
 			return try CC.crypt(
 				.decrypt, blockMode: .cbc, algorithm: .aes, padding: .pkcs7Padding,
 				data: data, key: key, iv: iv)
@@ -558,31 +561,31 @@ public class PEM {
 
 	}
 
-	private static func stripHeaderFooter(data: String, header: String, footer: String) -> String? {
+	fileprivate static func stripHeaderFooter(_ data: String, header: String, footer: String) -> String? {
 		guard data.hasPrefix(header) else {
 			return nil
 		}
-		guard let r = data.rangeOfString(footer) else {
+		guard let r = data.range(of: footer) else {
 			return nil
 		}
-		return data.substringWithRange(header.endIndex..<r.startIndex)
+		return data.substring(with: header.endIndex..<r.lowerBound)
 	}
 
-	private static func base64Decode(base64Data: String) -> NSData? {
-		return NSData(base64EncodedString: base64Data, options: [.IgnoreUnknownCharacters])
+	fileprivate static func base64Decode(_ base64Data: String) -> Data? {
+		return Data(base64Encoded: base64Data, options: [.ignoreUnknownCharacters])
 	}
 
-	private static func base64Encode(key: NSData) -> String {
-		return key.base64EncodedStringWithOptions(
-			[.Encoding64CharacterLineLength, .EncodingEndLineWithLineFeed])
+	fileprivate static func base64Encode(_ key: Data) -> String {
+		return key.base64EncodedString(
+			options: [.lineLength64Characters, .endLineWithLineFeed])
 	}
 
 }
 
-public class CC {
+open class CC {
 
 	public typealias CCCryptorStatus = Int32
-	public enum CCError: CCCryptorStatus, ErrorType {
+	public enum CCError: CCCryptorStatus, Error {
 		case paramError = -4300
 		case bufferTooSmall = -4301
 		case memoryFailure = -4302
@@ -609,9 +612,11 @@ public class CC {
 		}
 	}
 
-	public static func generateRandom(size: Int) -> NSData {
-		let data = NSMutableData(length: size)!
-		CCRandomGenerateBytes!(bytes: data.mutableBytes, count: size)
+	open static func generateRandom(_ size: Int) -> Data {
+		var data = Data(count: size)
+        data.withUnsafeMutableBytes { (dataBytes: UnsafeMutablePointer<UInt8>) -> Void in
+            _ = CCRandomGenerateBytes!(dataBytes, size)
+        }
 		return data
 	}
 
@@ -624,16 +629,18 @@ public class CC {
 		case sha224 = 9, sha256 = 10, sha384 = 11, sha512 = 12
 
 		var length: Int {
-			return CCDigestGetOutputSize!(algorithm: self.rawValue)
+			return CCDigestGetOutputSize!(self.rawValue)
 		}
 	}
 
-	public static func digest(data: NSData, alg: DigestAlgorithm) -> NSData {
-		let output = NSMutableData(length: alg.length)!
-		CCDigest!(algorithm: alg.rawValue,
-		          data: data.bytes,
-		          dataLen: data.length,
-		          output: output.mutableBytes)
+	open static func digest(_ data: Data, alg: DigestAlgorithm) -> Data {
+		var output = Data(count: alg.length)
+        output.withUnsafeMutableBytes { (outputBytes: UnsafeMutablePointer<UInt8>) -> Void in
+            _ = CCDigest!(alg.rawValue,
+                          (data as NSData).bytes,
+                          data.count,
+                          outputBytes)
+        }
 		return output
 	}
 
@@ -653,12 +660,14 @@ public class CC {
 		}
 	}
 
-	public static func HMAC(data: NSData, alg: HMACAlg, key: NSData) -> NSData {
-		let buffer = NSMutableData(length: alg.digestLength)!
-		CCHmac!(algorithm: alg.rawValue,
-		       key: key.bytes, keyLength: key.length,
-		       data: data.bytes, dataLength: data.length,
-		       macOut: buffer.mutableBytes)
+	open static func HMAC(_ data: Data, alg: HMACAlg, key: Data) -> Data {
+		var buffer = Data(count: alg.digestLength)
+        buffer.withUnsafeMutableBytes { (bufferBytes: UnsafeMutablePointer<UInt8>) -> Void in
+            CCHmac!(alg.rawValue,
+                    (key as NSData).bytes, key.count,
+                    (data as NSData).bytes, data.count,
+                    bufferBytes)
+        }
 		return buffer
 	}
 
@@ -704,66 +713,70 @@ public class CC {
 		case noPadding = 0, pkcs7Padding
 	}
 
-	public static func crypt(opMode: OpMode, blockMode: BlockMode,
+	open static func crypt(_ opMode: OpMode, blockMode: BlockMode,
 	                         algorithm: Algorithm, padding: Padding,
-	                         data: NSData, key: NSData, iv: NSData) throws -> NSData {
+	                         data: Data, key: Data, iv: Data) throws -> Data {
 		if blockMode.needIV {
-			guard iv.length == algorithm.blockSize else { throw CCError(.paramError) }
+			guard iv.count == algorithm.blockSize else { throw CCError(.paramError) }
 		}
 
-		var cryptor: CCCryptorRef = nil
+		var cryptor: CCCryptorRef? = nil
 		var status = CCCryptorCreateWithMode!(
-			op: opMode.rawValue, mode: blockMode.rawValue,
-			alg: algorithm.rawValue, padding: padding.rawValue,
-			iv: iv.bytes, key: key.bytes, keyLength: key.length,
-			tweak: nil, tweakLength: 0, numRounds: 0,
-			options: CCModeOptions(), cryptorRef: &cryptor)
+			opMode.rawValue, blockMode.rawValue,
+			algorithm.rawValue, padding.rawValue,
+			(iv as NSData).bytes, (key as NSData).bytes, key.count,
+			nil, 0, 0,
+			CCModeOptions(), &cryptor)
 		guard status == noErr else { throw CCError(status) }
 
-		defer { CCCryptorRelease!(cryptorRef: cryptor) }
+		defer { _ = CCCryptorRelease!(cryptor!) }
 
-		let needed = CCCryptorGetOutputLength!(cryptorRef: cryptor, inputLength: data.length, final: true)
-		let result = NSMutableData(length: needed)!
+		let needed = CCCryptorGetOutputLength!(cryptor!, data.count, true)
+		var result = Data(count: needed)
 		var updateLen: size_t = 0
-		status = CCCryptorUpdate!(
-			cryptorRef: cryptor,
-			dataIn: data.bytes, dataInLength: data.length,
-			dataOut: result.mutableBytes, dataOutAvailable: result.length,
-			dataOutMoved: &updateLen)
+        status = result.withUnsafeMutableBytes({ (resultBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+            return CCCryptorUpdate!(
+                cryptor!,
+                (data as NSData).bytes, data.count,
+                resultBytes, result.count,
+                &updateLen)
+        })
 		guard status == noErr else { throw CCError(status) }
 
 
 		var finalLen: size_t = 0
-		status = CCCryptorFinal!(
-			cryptorRef: cryptor,
-			dataOut: result.mutableBytes + updateLen,
-			dataOutAvailable: result.length - updateLen,
-			dataOutMoved: &finalLen)
+        status = result.withUnsafeMutableBytes({ (resultBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+            return CCCryptorFinal!(
+                cryptor!,
+                resultBytes + updateLen,
+                result.count - updateLen,
+                &finalLen)
+        })
 		guard status == noErr else { throw CCError(status) }
 
 
-		result.length = updateLen + finalLen
+		result.count = updateLen + finalLen
 		return result
 	}
 
 	//The same behaviour as in the CCM pdf
 	//http://csrc.nist.gov/publications/nistpubs/800-38C/SP800-38C_updated-July20_2007.pdf
-	public static func cryptAuth(opMode: OpMode, blockMode: AuthBlockMode, algorithm: Algorithm,
-	                             data: NSData, aData: NSData,
-	                             key: NSData, iv: NSData, tagLength: Int) throws -> NSData {
+	open static func cryptAuth(_ opMode: OpMode, blockMode: AuthBlockMode, algorithm: Algorithm,
+	                             data: Data, aData: Data,
+	                             key: Data, iv: Data, tagLength: Int) throws -> Data {
 		let cryptFun = blockMode == .gcm ? GCM.crypt : CCM.crypt
 		if opMode == .encrypt {
-			let (cipher, tag) = try cryptFun(opMode, algorithm: algorithm, data: data,
-			                                 key: key, iv: iv, aData: aData, tagLength: tagLength)
-			let result = NSMutableData(data: cipher)
-			result.appendData(tag)
+			let (cipher, tag) = try cryptFun(opMode, algorithm, data,
+			                                 key, iv, aData, tagLength)
+			var result = cipher
+			result.append(tag)
 			return result
 		} else {
-			let cipher = data.subdataWithRange(NSRange(location: 0, length: data.length - tagLength))
-			let tag = data.subdataWithRange(
-				NSRange(location: data.length - tagLength, length: tagLength))
-			let (plain, vTag) = try cryptFun(opMode, algorithm: algorithm, data: cipher,
-			                                 key: key, iv: iv, aData: aData, tagLength: tagLength)
+			let cipher = data.subdata(in: 0..<(data.count - tagLength))
+			let tag = data.subdata(
+				in: (data.count - tagLength)..<data.count)
+			let (plain, vTag) = try cryptFun(opMode, algorithm, cipher,
+			                                 key, iv, aData, tagLength)
 			guard tag == vTag else {
 				throw CCError(.decodeError)
 			}
@@ -771,20 +784,20 @@ public class CC {
 		}
 	}
 
-	public static func digestAvailable() -> Bool {
+	open static func digestAvailable() -> Bool {
 		return CCDigest != nil &&
 			CCDigestGetOutputSize != nil
 	}
 
-	public static func randomAvailable() -> Bool {
+	open static func randomAvailable() -> Bool {
 		return CCRandomGenerateBytes != nil
 	}
 
-	public static func hmacAvailable() -> Bool {
+	open static func hmacAvailable() -> Bool {
 		return CCHmac != nil
 	}
 
-	public static func cryptorAvailable() -> Bool {
+	open static func cryptorAvailable() -> Bool {
 		return CCCryptorCreateWithMode != nil &&
 			CCCryptorGetOutputLength != nil &&
 			CCCryptorUpdate != nil &&
@@ -792,7 +805,7 @@ public class CC {
 			CCCryptorRelease != nil
 	}
 
-	public static func available() -> Bool {
+	open static func available() -> Bool {
 		return digestAvailable() &&
 			randomAvailable() &&
 			hmacAvailable() &&
@@ -808,173 +821,184 @@ public class CC {
 			CCM.available()
 	}
 
-	private typealias CCCryptorRef = UnsafePointer<Void>
-	private typealias CCRNGStatus = CCCryptorStatus
-	private typealias CC_LONG = UInt32
-	private typealias CCModeOptions = UInt32
+	fileprivate typealias CCCryptorRef = UnsafeRawPointer
+	fileprivate typealias CCRNGStatus = CCCryptorStatus
+	fileprivate typealias CC_LONG = UInt32
+	fileprivate typealias CCModeOptions = UInt32
 
-	private typealias CCRandomGenerateBytesT = @convention(c) (
-		bytes: UnsafeMutablePointer<Void>,
-		count: size_t) -> CCRNGStatus
-	private typealias CCDigestGetOutputSizeT = @convention(c) (
-		algorithm: CCDigestAlgorithm) -> size_t
-	private typealias CCDigestT = @convention(c) (
-		algorithm: CCDigestAlgorithm,
-		data: UnsafePointer<Void>,
-		dataLen: size_t,
-		output: UnsafeMutablePointer<Void>) -> CInt
+	fileprivate typealias CCRandomGenerateBytesT = @convention(c) (
+		_ bytes: UnsafeMutableRawPointer,
+		_ count: size_t) -> CCRNGStatus
+	fileprivate typealias CCDigestGetOutputSizeT = @convention(c) (
+		_ algorithm: CCDigestAlgorithm) -> size_t
+	fileprivate typealias CCDigestT = @convention(c) (
+		_ algorithm: CCDigestAlgorithm,
+		_ data: UnsafeRawPointer,
+		_ dataLen: size_t,
+		_ output: UnsafeMutableRawPointer) -> CInt
 
-	private typealias CCHmacT = @convention(c) (
-		algorithm: CCHmacAlgorithm,
-		key: UnsafePointer<Void>,
-		keyLength: Int,
-		data: UnsafePointer<Void>,
-		dataLength: Int,
-		macOut: UnsafeMutablePointer<Void>) -> Void
-	private typealias CCCryptorCreateWithModeT = @convention(c)(
-		op: CCOperation,
-		mode: CCMode,
-		alg: CCAlgorithm,
-		padding: CCPadding,
-		iv: UnsafePointer<Void>,
-		key: UnsafePointer<Void>, keyLength: Int,
-		tweak: UnsafePointer<Void>, tweakLength: Int,
-		numRounds: Int32, options: CCModeOptions,
-		cryptorRef: UnsafeMutablePointer<CCCryptorRef>) -> CCCryptorStatus
-	private typealias CCCryptorGetOutputLengthT = @convention(c)(
-		cryptorRef: CCCryptorRef,
-		inputLength: size_t,
-		final: Bool) -> size_t
-	private typealias CCCryptorUpdateT = @convention(c)(
-		cryptorRef: CCCryptorRef,
-		dataIn: UnsafePointer<Void>,
-		dataInLength: Int,
-		dataOut: UnsafeMutablePointer<Void>,
-		dataOutAvailable: Int,
-		dataOutMoved: UnsafeMutablePointer<Int>) -> CCCryptorStatus
-	private typealias CCCryptorFinalT = @convention(c)(
-		cryptorRef: CCCryptorRef,
-		dataOut: UnsafeMutablePointer<Void>,
-		dataOutAvailable: Int,
-		dataOutMoved: UnsafeMutablePointer<Int>) -> CCCryptorStatus
-	private typealias CCCryptorReleaseT = @convention(c)
-		(cryptorRef: CCCryptorRef) -> CCCryptorStatus
+	fileprivate typealias CCHmacT = @convention(c) (
+		_ algorithm: CCHmacAlgorithm,
+		_ key: UnsafeRawPointer,
+		_ keyLength: Int,
+		_ data: UnsafeRawPointer,
+		_ dataLength: Int,
+		_ macOut: UnsafeMutableRawPointer) -> Void
+	fileprivate typealias CCCryptorCreateWithModeT = @convention(c)(
+		_ op: CCOperation,
+		_ mode: CCMode,
+		_ alg: CCAlgorithm,
+		_ padding: CCPadding,
+		_ iv: UnsafeRawPointer?,
+		_ key: UnsafeRawPointer, _ keyLength: Int,
+		_ tweak: UnsafeRawPointer?, _ tweakLength: Int,
+		_ numRounds: Int32, _ options: CCModeOptions,
+		_ cryptorRef: UnsafeMutablePointer<CCCryptorRef?>) -> CCCryptorStatus
+	fileprivate typealias CCCryptorGetOutputLengthT = @convention(c)(
+		_ cryptorRef: CCCryptorRef,
+		_ inputLength: size_t,
+		_ final: Bool) -> size_t
+	fileprivate typealias CCCryptorUpdateT = @convention(c)(
+		_ cryptorRef: CCCryptorRef,
+		_ dataIn: UnsafeRawPointer,
+		_ dataInLength: Int,
+		_ dataOut: UnsafeMutableRawPointer,
+		_ dataOutAvailable: Int,
+		_ dataOutMoved: UnsafeMutablePointer<Int>) -> CCCryptorStatus
+	fileprivate typealias CCCryptorFinalT = @convention(c)(
+		_ cryptorRef: CCCryptorRef,
+		_ dataOut: UnsafeMutableRawPointer,
+		_ dataOutAvailable: Int,
+		_ dataOutMoved: UnsafeMutablePointer<Int>) -> CCCryptorStatus
+	fileprivate typealias CCCryptorReleaseT = @convention(c)
+		(_ cryptorRef: CCCryptorRef) -> CCCryptorStatus
 
 
-	private static let dl = dlopen("/usr/lib/system/libcommonCrypto.dylib", RTLD_NOW)
-	private static let CCRandomGenerateBytes: CCRandomGenerateBytesT? =
-		getFunc(dl, f: "CCRandomGenerateBytes")
-	private static let CCDigestGetOutputSize: CCDigestGetOutputSizeT? =
-		getFunc(dl, f: "CCDigestGetOutputSize")
-	private static let CCDigest: CCDigestT? = getFunc(dl, f: "CCDigest")
-	private static let CCHmac: CCHmacT? = getFunc(dl, f: "CCHmac")
-	private static let CCCryptorCreateWithMode: CCCryptorCreateWithModeT? =
-		getFunc(dl, f: "CCCryptorCreateWithMode")
-	private static let CCCryptorGetOutputLength: CCCryptorGetOutputLengthT? =
-		getFunc(dl, f: "CCCryptorGetOutputLength")
-	private static let CCCryptorUpdate: CCCryptorUpdateT? =
-		getFunc(dl, f: "CCCryptorUpdate")
-	private static let CCCryptorFinal: CCCryptorFinalT? =
-		getFunc(dl, f: "CCCryptorFinal")
-	private static let CCCryptorRelease: CCCryptorReleaseT? =
-		getFunc(dl, f: "CCCryptorRelease")
+	fileprivate static let dl = dlopen("/usr/lib/system/libcommonCrypto.dylib", RTLD_NOW)
+	fileprivate static let CCRandomGenerateBytes: CCRandomGenerateBytesT? =
+		getFunc(dl!, f: "CCRandomGenerateBytes")
+	fileprivate static let CCDigestGetOutputSize: CCDigestGetOutputSizeT? =
+		getFunc(dl!, f: "CCDigestGetOutputSize")
+	fileprivate static let CCDigest: CCDigestT? = getFunc(dl!, f: "CCDigest")
+	fileprivate static let CCHmac: CCHmacT? = getFunc(dl!, f: "CCHmac")
+	fileprivate static let CCCryptorCreateWithMode: CCCryptorCreateWithModeT? =
+		getFunc(dl!, f: "CCCryptorCreateWithMode")
+	fileprivate static let CCCryptorGetOutputLength: CCCryptorGetOutputLengthT? =
+		getFunc(dl!, f: "CCCryptorGetOutputLength")
+	fileprivate static let CCCryptorUpdate: CCCryptorUpdateT? =
+		getFunc(dl!, f: "CCCryptorUpdate")
+	fileprivate static let CCCryptorFinal: CCCryptorFinalT? =
+		getFunc(dl!, f: "CCCryptorFinal")
+	fileprivate static let CCCryptorRelease: CCCryptorReleaseT? =
+		getFunc(dl!, f: "CCCryptorRelease")
 
-	public class GCM {
+	open class GCM {
 
-		public static func crypt(opMode: OpMode, algorithm: Algorithm, data: NSData,
-		                         key: NSData, iv: NSData,
-		                         aData: NSData, tagLength: Int) throws -> (NSData, NSData) {
-			let result = NSMutableData(length: data.length)!
+		open static func crypt(_ opMode: OpMode, algorithm: Algorithm, data: Data,
+		                         key: Data, iv: Data,
+		                         aData: Data, tagLength: Int) throws -> (Data, Data) {
+			var result = Data(count: data.count)
 			var tagLength_ = tagLength
-			let tag = NSMutableData(length: tagLength)!
-			let status = CCCryptorGCM!(op: opMode.rawValue, alg: algorithm.rawValue,
-				key: key.bytes, keyLength: key.length, iv: iv.bytes, ivLen: iv.length,
-				aData: aData.bytes, aDataLen: aData.length,
-				dataIn: data.bytes, dataInLength: data.length,
-				dataOut: result.mutableBytes, tag: tag.bytes, tagLength: &tagLength_)
+			var tag = Data(count: tagLength)
+            let status = result.withUnsafeMutableBytes {
+                (resultBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return tag.withUnsafeMutableBytes({ (tagBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                    return CCCryptorGCM!(opMode.rawValue, algorithm.rawValue,
+                                         (key as NSData).bytes, key.count, (iv as NSData).bytes, iv.count,
+                                         (aData as NSData).bytes, aData.count,
+                                         (data as NSData).bytes, data.count,
+                                         resultBytes, tagBytes, &tagLength_)
+                })
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			tag.length = tagLength_
+			tag.count = tagLength_
 			return (result, tag)
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			if CCCryptorGCM != nil {
 				return true
 			}
 			return false
 		}
 
-		private typealias CCCryptorGCMT = @convention(c) (op: CCOperation, alg: CCAlgorithm,
-			key: UnsafePointer<Void>, keyLength: Int,
-			iv: UnsafePointer<Void>, ivLen: Int,
-			aData: UnsafePointer<Void>, aDataLen: Int,
-			dataIn: UnsafePointer<Void>, dataInLength: Int,
-			dataOut: UnsafeMutablePointer<Void>,
-			tag: UnsafePointer<Void>, tagLength: UnsafeMutablePointer<Int>) -> CCCryptorStatus
-		private static let CCCryptorGCM: CCCryptorGCMT? = getFunc(dl, f: "CCCryptorGCM")
+		fileprivate typealias CCCryptorGCMT = @convention(c) (_ op: CCOperation, _ alg: CCAlgorithm,
+			_ key: UnsafeRawPointer, _ keyLength: Int,
+			_ iv: UnsafeRawPointer, _ ivLen: Int,
+			_ aData: UnsafeRawPointer, _ aDataLen: Int,
+			_ dataIn: UnsafeRawPointer, _ dataInLength: Int,
+			_ dataOut: UnsafeMutableRawPointer,
+			_ tag: UnsafeRawPointer, _ tagLength: UnsafeMutablePointer<Int>) -> CCCryptorStatus
+		fileprivate static let CCCryptorGCM: CCCryptorGCMT? = getFunc(dl!, f: "CCCryptorGCM")
 
 	}
 
-	public class CCM {
+	open class CCM {
 
-		public static func crypt(opMode: OpMode, algorithm: Algorithm, data: NSData,
-		                         key: NSData, iv: NSData,
-		                         aData: NSData, tagLength: Int) throws -> (NSData, NSData) {
-			var cryptor: CCCryptorRef = nil
+		open static func crypt(_ opMode: OpMode, algorithm: Algorithm, data: Data,
+		                         key: Data, iv: Data,
+		                         aData: Data, tagLength: Int) throws -> (Data, Data) {
+			var cryptor: CCCryptorRef? = nil
 			var status = CCCryptorCreateWithMode!(
-				op: opMode.rawValue, mode: AuthBlockMode.ccm.rawValue,
-				alg: algorithm.rawValue, padding: Padding.noPadding.rawValue,
-				iv: nil, key: key.bytes, keyLength: key.length, tweak: nil, tweakLength: 0,
-				numRounds: 0, options: CCModeOptions(), cryptorRef: &cryptor)
+				opMode.rawValue, AuthBlockMode.ccm.rawValue,
+				algorithm.rawValue, Padding.noPadding.rawValue,
+				nil, (key as NSData).bytes, key.count, nil, 0,
+				0, CCModeOptions(), &cryptor)
 			guard status == noErr else { throw CCError(status) }
-			defer { CCCryptorRelease!(cryptorRef: cryptor) }
+			defer { _ = CCCryptorRelease!(cryptor!) }
 
-			status = CCCryptorAddParameter!(cryptorRef: cryptor,
-				parameter: Parameter.dataSize.rawValue, data: nil, dataLength: data.length)
-			guard status == noErr else { throw CCError(status) }
-
-			status = CCCryptorAddParameter!(cryptorRef: cryptor,
-				parameter: Parameter.macSize.rawValue, data: nil, dataLength: tagLength)
+			status = CCCryptorAddParameter!(cryptor!,
+				Parameter.dataSize.rawValue, nil, data.count)
 			guard status == noErr else { throw CCError(status) }
 
-			status = CCCryptorAddParameter!(cryptorRef: cryptor,
-				parameter: Parameter.iv.rawValue, data: iv.bytes, dataLength: iv.length)
+			status = CCCryptorAddParameter!(cryptor!,
+				Parameter.macSize.rawValue, nil, tagLength)
 			guard status == noErr else { throw CCError(status) }
 
-			status = CCCryptorAddParameter!(cryptorRef: cryptor,
-				parameter: Parameter.authData.rawValue, data: aData.bytes, dataLength: aData.length)
+			status = CCCryptorAddParameter!(cryptor!,
+				Parameter.iv.rawValue, (iv as NSData).bytes, iv.count)
 			guard status == noErr else { throw CCError(status) }
 
-			let result = NSMutableData(length: data.length)!
+			status = CCCryptorAddParameter!(cryptor!,
+				Parameter.authData.rawValue, (aData as NSData).bytes, aData.count)
+			guard status == noErr else { throw CCError(status) }
+
+			var result = Data(count: data.count)
 
 			var updateLen: size_t = 0
-			status = CCCryptorUpdate!(
-				cryptorRef: cryptor, dataIn: data.bytes, dataInLength: data.length,
-				dataOut: result.mutableBytes, dataOutAvailable: result.length,
-				dataOutMoved: &updateLen)
+            status = result.withUnsafeMutableBytes({ (resultBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCCryptorUpdate!(
+                    cryptor!, (data as NSData).bytes, data.count,
+                    resultBytes, result.count,
+                    &updateLen)
+            })
 			guard status == noErr else { throw CCError(status) }
 
 			var finalLen: size_t = 0
-			status = CCCryptorFinal!(cryptorRef: cryptor, dataOut: result.mutableBytes + updateLen,
-			                         dataOutAvailable: result.length - updateLen,
-			                         dataOutMoved: &finalLen)
+            status = result.withUnsafeMutableBytes({ (resultBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCCryptorFinal!(cryptor!, resultBytes + updateLen,
+                                       result.count - updateLen,
+                                       &finalLen)
+            })
 			guard status == noErr else { throw CCError(status) }
 
-			result.length = updateLen + finalLen
+			result.count = updateLen + finalLen
 
 			var tagLength_ = tagLength
-			let tag = NSMutableData(length: tagLength)!
-			status = CCCryptorGetParameter!(cryptorRef: cryptor, parameter: Parameter.authTag.rawValue,
-			                                data: tag.bytes, dataLength: &tagLength_)
+			var tag = Data(count: tagLength)
+            status = tag.withUnsafeMutableBytes({ (tagBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCCryptorGetParameter!(cryptor!, Parameter.authTag.rawValue,
+                                              tagBytes, &tagLength_)
+            })
 			guard status == noErr else { throw CCError(status) }
 
-			tag.length = tagLength_
+			tag.count = tagLength_
 
 			return (result, tag)
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			if CCCryptorAddParameter != nil &&
 				CCCryptorGetParameter != nil {
 				return true
@@ -982,24 +1006,24 @@ public class CC {
 			return false
 		}
 
-		private typealias CCParameter = UInt32
-		private enum Parameter: CCParameter {
+		fileprivate typealias CCParameter = UInt32
+		fileprivate enum Parameter: CCParameter {
 			case iv, authData, macSize, dataSize, authTag
 		}
-		private typealias CCCryptorAddParameterT = @convention(c) (cryptorRef: CCCryptorRef,
-			parameter: CCParameter,
-			data: UnsafePointer<Void>, dataLength: size_t) -> CCCryptorStatus
-		private static let CCCryptorAddParameter: CCCryptorAddParameterT? =
-			getFunc(dl, f: "CCCryptorAddParameter")
+		fileprivate typealias CCCryptorAddParameterT = @convention(c) (_ cryptorRef: CCCryptorRef,
+			_ parameter: CCParameter,
+			_ data: UnsafeRawPointer?, _ dataLength: size_t) -> CCCryptorStatus
+		fileprivate static let CCCryptorAddParameter: CCCryptorAddParameterT? =
+			getFunc(dl!, f: "CCCryptorAddParameter")
 
-		private typealias CCCryptorGetParameterT = @convention(c) (cryptorRef: CCCryptorRef,
-			parameter: CCParameter,
-			data: UnsafePointer<Void>, dataLength: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
-		private static let CCCryptorGetParameter: CCCryptorGetParameterT? =
-			getFunc(dl, f: "CCCryptorGetParameter")
+		fileprivate typealias CCCryptorGetParameterT = @convention(c) (_ cryptorRef: CCCryptorRef,
+			_ parameter: CCParameter,
+			_ data: UnsafeRawPointer, _ dataLength: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
+		fileprivate static let CCCryptorGetParameter: CCCryptorGetParameterT? =
+			getFunc(dl!, f: "CCCryptorGetParameter")
 	}
 
-	public class RSA {
+	open class RSA {
 
 		public typealias CCAsymmetricPadding = UInt32
 
@@ -1013,111 +1037,116 @@ public class CC {
 			case pss = 1002
 		}
 
-		public static func generateKeyPair(keySize: Int = 4096) throws -> (NSData, NSData) {
-			var privateKey: CCRSACryptorRef = nil
-			var publicKey: CCRSACryptorRef = nil
+		open static func generateKeyPair(_ keySize: Int = 4096) throws -> (Data, Data) {
+			var privateKey: CCRSACryptorRef? = nil
+			var publicKey: CCRSACryptorRef? = nil
 			let status = CCRSACryptorGeneratePair!(
-				keySize: keySize,
-				e: 65537,
-				publicKey: &publicKey,
-				privateKey: &privateKey)
+				keySize,
+				65537,
+				&publicKey,
+				&privateKey)
 			guard status == noErr else { throw CCError(status) }
 
 			defer {
-				CCRSACryptorRelease!(privateKey)
-				CCRSACryptorRelease!(publicKey)
+				CCRSACryptorRelease!(privateKey!)
+				CCRSACryptorRelease!(publicKey!)
 			}
 
-			let privDERKey = try exportToDERKey(privateKey)
-			let pubDERKey = try exportToDERKey(publicKey)
+			let privDERKey = try exportToDERKey(privateKey!)
+			let pubDERKey = try exportToDERKey(publicKey!)
 
 			return (privDERKey, pubDERKey)
 		}
 
-		public static func encrypt(data: NSData, derKey: NSData, tag: NSData, padding: AsymmetricPadding,
-		                           digest: DigestAlgorithm) throws -> NSData {
+		open static func encrypt(_ data: Data, derKey: Data, tag: Data, padding: AsymmetricPadding,
+		                           digest: DigestAlgorithm) throws -> Data {
 			let key = try importFromDERKey(derKey)
 			defer { CCRSACryptorRelease!(key) }
 
 			var bufferSize = getKeySize(key)
-			let buffer = NSMutableData(length: bufferSize)!
+			var buffer = Data(count: bufferSize)
 
-			let status = CCRSACryptorEncrypt!(
-				publicKey: key,
-				padding: padding.rawValue,
-				plainText: data.bytes,
-				plainTextLen: data.length,
-				cipherText: buffer.mutableBytes,
-				cipherTextLen: &bufferSize,
-				tagData: tag.bytes, tagDataLen: tag.length,
-				digestType: digest.rawValue)
+            let status = buffer.withUnsafeMutableBytes {
+                (bufferBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCRSACryptorEncrypt!(
+                    key,
+                    padding.rawValue,
+                    (data as NSData).bytes,
+                    data.count,
+                    bufferBytes,
+                    &bufferSize,
+                    (tag as NSData).bytes, tag.count,
+                    digest.rawValue)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-
-			buffer.length = bufferSize
+			buffer.count = bufferSize
 
 			return buffer
 		}
 
-		public static func decrypt(data: NSData, derKey: NSData, tag: NSData, padding: AsymmetricPadding,
-		                           digest: DigestAlgorithm) throws -> (NSData, Int) {
+		open static func decrypt(_ data: Data, derKey: Data, tag: Data, padding: AsymmetricPadding,
+		                           digest: DigestAlgorithm) throws -> (Data, Int) {
 			let key = try importFromDERKey(derKey)
 			defer { CCRSACryptorRelease!(key) }
 
 			let blockSize = getKeySize(key)
 
 			var bufferSize = blockSize
-			let buffer = NSMutableData(length: bufferSize)!
+			var buffer = Data(count: bufferSize)
 
-			let status = CCRSACryptorDecrypt!(
-				privateKey: key,
-				padding: padding.rawValue,
-				cipherText: data.bytes,
-				cipherTextLen: bufferSize,
-				plainText: buffer.mutableBytes,
-				plainTextLen: &bufferSize,
-				tagData: tag.bytes, tagDataLen: tag.length,
-				digestType: digest.rawValue)
+            let status = buffer.withUnsafeMutableBytes {
+                (bufferBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCRSACryptorDecrypt!(
+                    key,
+                    padding.rawValue,
+                    (data as NSData).bytes,
+                    bufferSize,
+                    bufferBytes,
+                    &bufferSize,
+                    (tag as NSData).bytes, tag.count,
+                    digest.rawValue)
+            }
 			guard status == noErr else { throw CCError(status) }
-			buffer.length = bufferSize
+			buffer.count = bufferSize
 
 			return (buffer, blockSize)
 		}
 
-		private static func importFromDERKey(derKey: NSData) throws -> CCRSACryptorRef {
-			var key: CCRSACryptorRef = nil
+		fileprivate static func importFromDERKey(_ derKey: Data) throws -> CCRSACryptorRef {
+			var key: CCRSACryptorRef? = nil
 			let status = CCRSACryptorImport!(
-				keyPackage: derKey.bytes,
-				keyPackageLen: derKey.length,
-				key: &key)
+				(derKey as NSData).bytes,
+				derKey.count,
+				&key)
 			guard status == noErr else { throw CCError(status) }
 
-			return key
+			return key!
 		}
 
-		private static func exportToDERKey(key: CCRSACryptorRef) throws -> NSData {
+		fileprivate static func exportToDERKey(_ key: CCRSACryptorRef) throws -> Data {
 			var derKeyLength = 8192
-			let derKey = NSMutableData(length: derKeyLength)!
-			let status = CCRSACryptorExport!(
-				key: key,
-				out: derKey.mutableBytes,
-				outLen: &derKeyLength)
+			var derKey = Data(count: derKeyLength)
+            let status = derKey.withUnsafeMutableBytes {
+                (derKeyBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCRSACryptorExport!(key, derKeyBytes, &derKeyLength)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			derKey.length = derKeyLength
+			derKey.count = derKeyLength
 			return derKey
 		}
 
-		private static func getKeyType(key: CCRSACryptorRef) -> KeyType {
+		fileprivate static func getKeyType(_ key: CCRSACryptorRef) -> KeyType {
 			return KeyType(rawValue: CCRSAGetKeyType!(key))!
 		}
 
-		private static func getKeySize(key: CCRSACryptorRef) -> Int {
+		fileprivate static func getKeySize(_ key: CCRSACryptorRef) -> Int {
 			return Int(CCRSAGetKeySize!(key)/8)
 		}
 
-		public static func sign(message: NSData, derKey: NSData, padding: AsymmetricSAPadding,
-		                        digest: DigestAlgorithm, saltLen: Int) throws -> NSData {
+		open static func sign(_ message: Data, derKey: Data, padding: AsymmetricSAPadding,
+		                        digest: DigestAlgorithm, saltLen: Int) throws -> Data {
 			let key = try importFromDERKey(derKey)
 			defer { CCRSACryptorRelease!(key) }
 			guard getKeyType(key) == .privateKey else { throw CCError(.paramError) }
@@ -1128,16 +1157,19 @@ public class CC {
 			case .pkcs15:
 				let hash = CC.digest(message, alg: digest)
 				var signedDataLength = keySize
-				let signedData = NSMutableData(length:signedDataLength)!
-				let status = CCRSACryptorSign!(
-					privateKey: key,
-					padding: AsymmetricPadding.pkcs1.rawValue,
-					hashToSign: hash.bytes, hashSignLen: hash.length,
-					digestType: digest.rawValue, saltLen: 0 /*unused*/,
-					signedData: signedData.mutableBytes, signedDataLen: &signedDataLength)
+				var signedData = Data(count:signedDataLength)
+                let status = signedData.withUnsafeMutableBytes({
+                    (signedDataBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                    return CCRSACryptorSign!(
+                        key,
+                        AsymmetricPadding.pkcs1.rawValue,
+                        (hash as NSData).bytes, hash.count,
+                        digest.rawValue, 0 /*unused*/,
+                        signedDataBytes, &signedDataLength)
+                })
 				guard status == noErr else { throw CCError(status) }
 
-				signedData.length = signedDataLength
+				signedData.count = signedDataLength
 				return signedData
 			case .pss:
 				let encMessage = try add_pss_padding(
@@ -1149,9 +1181,9 @@ public class CC {
 			}
 		}
 
-		public static func verify(message: NSData, derKey: NSData, padding: AsymmetricSAPadding,
+		open static func verify(_ message: Data, derKey: Data, padding: AsymmetricSAPadding,
 		                          digest: DigestAlgorithm, saltLen: Int,
-		                          signedData: NSData) throws -> Bool {
+		                          signedData: Data) throws -> Bool {
 			let key = try importFromDERKey(derKey)
 			defer { CCRSACryptorRelease!(key) }
 			guard getKeyType(key) == .publicKey else { throw CCError(.paramError) }
@@ -1162,11 +1194,11 @@ public class CC {
 			case .pkcs15:
 				let hash = CC.digest(message, alg: digest)
 				let status = CCRSACryptorVerify!(
-					publicKey: key,
-					padding: padding.rawValue,
-					hash: hash.bytes, hashLen: hash.length,
-					digestType: digest.rawValue, saltLen: 0 /*unused*/,
-					signedData: signedData.bytes, signedDataLen:signedData.length)
+					key,
+					padding.rawValue,
+					(hash as NSData).bytes, hash.count,
+					digest.rawValue, 0 /*unused*/,
+					(signedData as NSData).bytes, signedData.count)
 				let kCCNotVerified: CCCryptorStatus = -4306
 				if status == kCCNotVerified {
 					return false
@@ -1184,30 +1216,32 @@ public class CC {
 			}
 		}
 
-		private static func crypt(data: NSData, key: CCRSACryptorRef) throws -> NSData {
-			var outLength = data.length
-			let out = NSMutableData(length: outLength)!
-			let status = CCRSACryptorCrypt!(
-				rsaKey: key,
-				data: data.bytes, dataLength: data.length,
-				out: out.mutableBytes, outLength: &outLength)
+		fileprivate static func crypt(_ data: Data, key: CCRSACryptorRef) throws -> Data {
+			var outLength = data.count
+			var out = Data(count: outLength)
+            let status = out.withUnsafeMutableBytes { (outBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCRSACryptorCrypt!(
+                        key,
+                        (data as NSData).bytes, data.count,
+                        outBytes, &outLength)
+            }
 			guard status == noErr else { throw CCError(status) }
-			out.length = outLength
+			out.count = outLength
 
 			return out
 		}
 
-		private static func mgf1(digest: DigestAlgorithm,
-		                         seed: NSData, maskLength: Int) -> NSMutableData {
-			let tseed = NSMutableData(data: seed)
-			tseed.increaseLengthBy(4)
+		fileprivate static func mgf1(_ digest: DigestAlgorithm,
+		                         seed: Data, maskLength: Int) -> Data {
+			var tseed = seed
+            tseed.append(contentsOf: [0,0,0,0] as [UInt8])
 
 			var interval = maskLength / digest.length
 			if  maskLength % digest.length != 0 {
 				interval += 1
 			}
 
-			func pack(n: Int) -> [UInt8] {
+			func pack(_ n: Int) -> [UInt8] {
 				return [
 					UInt8(n>>24 & 0xff),
 					UInt8(n>>16 & 0xff),
@@ -1216,34 +1250,33 @@ public class CC {
 				]
 			}
 
-			let mask = NSMutableData()
+			var mask = Data()
 			for counter in 0 ..< interval {
-				tseed.replaceBytesInRange(NSRange(location: tseed.length - 4, length: 4),
-				                          withBytes: pack(counter))
-				mask.appendData(CC.digest(tseed, alg: digest))
+				tseed.replaceSubrange((tseed.count - 4) ..< tseed.count, with: pack(counter))
+				mask.append(CC.digest(tseed, alg: digest))
 			}
-			mask.length = maskLength
+			mask.count = maskLength
 			return mask
 		}
 
-		private static func xorData(data1: NSData, _ data2: NSData) -> NSMutableData {
-			precondition(data1.length == data2.length)
+		fileprivate static func xorData(_ data1: Data, _ data2: Data) -> Data {
+			precondition(data1.count == data2.count)
 
-			let ret = NSMutableData(length:data1.length)!
-			let r = UnsafeMutablePointer<UInt8>(ret.mutableBytes)
-
-			let bytes1 = UnsafePointer<UInt8>(data1.bytes)
-			let bytes2 = UnsafePointer<UInt8>(data2.bytes)
-			for i in 0 ..< ret.length {
-				r[i] = bytes1[i] ^ bytes2[i]
-			}
+            var ret = Data(count: data1.count)
+            ret.withUnsafeMutableBytes { (r: UnsafeMutablePointer<UInt8>) -> Void in
+                let bytes1 = (data1 as NSData).bytes.bindMemory(to: UInt8.self, capacity: data1.count)
+                let bytes2 = (data2 as NSData).bytes.bindMemory(to: UInt8.self, capacity: data2.count)
+                for i in 0 ..< ret.count {
+                    r[i] = bytes1[i] ^ bytes2[i]
+                }
+            }
 			return ret
 		}
 
-		private static func add_pss_padding(digest: DigestAlgorithm,
+		fileprivate static func add_pss_padding(_ digest: DigestAlgorithm,
 		                                   saltLength: Int,
 		                                   keyLength: Int,
-		                                   message: NSData) throws -> NSData {
+		                                   message: Data) throws -> Data {
 
 			if keyLength < 16 || saltLength < 0 {
 				throw CCError(.paramError)
@@ -1259,41 +1292,43 @@ public class CC {
 
 			let hash = CC.digest(message, alg: digest)
 
-			if emLength < hash.length + saltLength + 2 {
+			if emLength < hash.count + saltLength + 2 {
 				throw CCError(.paramError)
 			}
 
 			let salt = CC.generateRandom(saltLength)
 
-			let mPrime = NSMutableData(length: 8)!
-			mPrime.appendData(hash)
-			mPrime.appendData(salt)
+			var mPrime = Data(count: 8)
+			mPrime.append(hash)
+			mPrime.append(salt)
 			let mPrimeHash = CC.digest(mPrime, alg: digest)
 
-			let padding = NSMutableData(length: emLength - saltLength - hash.length - 2)!
-			let db = NSMutableData(data: padding)
-			db.appendBytes([0x01] as [UInt8], length: 1)
-			db.appendData(salt)
-			let dbMask = mgf1(digest, seed: mPrimeHash, maskLength: emLength - hash.length - 1)
-			let maskedDB = xorData(db, dbMask)
+			let padding = Data(count: emLength - saltLength - hash.count - 2)
+			var db = padding
+			db.append([0x01] as [UInt8], count: 1)
+			db.append(salt)
+			let dbMask = mgf1(digest, seed: mPrimeHash, maskLength: emLength - hash.count - 1)
+			var maskedDB = xorData(db, dbMask)
 
 			let zeroBits = 8 * emLength - emBits
-			UnsafeMutablePointer<UInt8>(maskedDB.mutableBytes)[0] &= UInt8(0xff >> zeroBits)
+            maskedDB.withUnsafeMutableBytes { (mMaskedDb: UnsafeMutablePointer<UInt8>) -> Void in
+                mMaskedDb[0] &= UInt8(0xff >> zeroBits)
+            }
 
-			let ret = NSMutableData(data:maskedDB)
-			ret.appendData(mPrimeHash)
-			ret.appendBytes([0xBC] as [UInt8], length: 1)
+			var ret = maskedDB
+			ret.append(mPrimeHash)
+			ret.append([0xBC] as [UInt8], count: 1)
 			return ret
 		}
 
-		private static func verify_pss_padding(digest: DigestAlgorithm,
+		fileprivate static func verify_pss_padding(_ digest: DigestAlgorithm,
 		                                      saltLength: Int, keyLength: Int,
-		                                      message: NSData, encMessage: NSData) throws -> Bool {
+		                                      message: Data, encMessage: Data) throws -> Bool {
 			if keyLength < 16 || saltLength < 0 {
 				throw CCError(.paramError)
 			}
 
-			guard encMessage.length > 0 else {
+			guard encMessage.count > 0 else {
 				return false
 			}
 
@@ -1305,38 +1340,38 @@ public class CC {
 
 			let hash = CC.digest(message, alg: digest)
 
-			if emLength < hash.length + saltLength + 2 {
+			if emLength < hash.count + saltLength + 2 {
 				return false
 			}
-			if encMessage.bytesView[encMessage.length-1] != 0xBC {
+			if encMessage.bytesView[encMessage.count-1] != 0xBC {
 				return false
 			}
 			let zeroBits = 8 * emLength - emBits
 			let zeroBitsM = 8 - zeroBits
-			let maskedDBLength = emLength - hash.length - 1
-			let maskedDB = encMessage.subdataWithRange(NSRange(location: 0, length: maskedDBLength))
+			let maskedDBLength = emLength - hash.count - 1
+			let maskedDB = encMessage.subdata(in: 0..<maskedDBLength)
 			if Int(maskedDB.bytesView[0]) >> zeroBitsM != 0 {
 				return false
 			}
-			let mPrimeHash = encMessage.subdataWithRange(
-				NSRange(location: maskedDBLength, length: hash.length))
-			let dbMask = mgf1(digest, seed: mPrimeHash, maskLength: emLength - hash.length - 1)
-			let db = xorData(maskedDB, dbMask)
-			UnsafeMutablePointer<UInt8>(db.mutableBytes)[0] &= UInt8(0xff >> zeroBits)
+			let mPrimeHash = encMessage.subdata(in: maskedDBLength ..< maskedDBLength + hash.count)
+			let dbMask = mgf1(digest, seed: mPrimeHash, maskLength: emLength - hash.count - 1)
+			var db = xorData(maskedDB, dbMask)
+            db.withUnsafeMutableBytes { (mDb: UnsafeMutablePointer<UInt8>) -> Void in
+                mDb[0] &= UInt8(0xff >> zeroBits)
+            }
 
-			let zeroLength = emLength - hash.length - saltLength - 2
-			let zeroString = NSMutableData(length:zeroLength)
-			if db.subdataWithRange(NSRange(location: 0, length: zeroLength)) != zeroString {
+			let zeroLength = emLength - hash.count - saltLength - 2
+			let zeroString = Data(count:zeroLength)
+			if db.subdata(in: 0 ..< zeroLength) != zeroString {
 				return false
 			}
 			if db.bytesView[zeroLength] != 0x01 {
 				return false
 			}
-			let salt = db.subdataWithRange(
-				NSRange(location:db.length - saltLength, length:saltLength))
-			let mPrime = NSMutableData(length:8)!
-			mPrime.appendData(hash)
-			mPrime.appendData(salt)
+			let salt = db.subdata(in: (db.count - saltLength) ..< db.count)
+			var mPrime = Data(count:8)
+			mPrime.append(hash)
+			mPrime.append(salt)
 			let mPrimeHash2 = CC.digest(mPrime, alg: digest)
 			if mPrimeHash != mPrimeHash2 {
 				return false
@@ -1345,7 +1380,7 @@ public class CC {
 		}
 
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CCRSACryptorGeneratePair != nil &&
 				CCRSACryptorRelease != nil &&
 				CCRSAGetKeyType != nil &&
@@ -1359,143 +1394,145 @@ public class CC {
 				CCRSACryptorCrypt != nil
 		}
 
-		private typealias CCRSACryptorRef = UnsafePointer<Void>
-		private typealias CCRSAKeyType = UInt32
-		private enum KeyType: CCRSAKeyType {
+		fileprivate typealias CCRSACryptorRef = UnsafeRawPointer
+		fileprivate typealias CCRSAKeyType = UInt32
+		fileprivate enum KeyType: CCRSAKeyType {
 			case publicKey = 0, privateKey
 			case blankPublicKey = 97, blankPrivateKey
 			case badKey = 99
 		}
 
-		private typealias CCRSACryptorGeneratePairT = @convention(c) (
-			keySize: Int,
-			e: UInt32,
-			publicKey: UnsafeMutablePointer<CCRSACryptorRef>,
-			privateKey: UnsafeMutablePointer<CCRSACryptorRef>) -> CCCryptorStatus
-		private static let CCRSACryptorGeneratePair: CCRSACryptorGeneratePairT? =
-			getFunc(CC.dl, f: "CCRSACryptorGeneratePair")
+		fileprivate typealias CCRSACryptorGeneratePairT = @convention(c) (
+			_ keySize: Int,
+			_ e: UInt32,
+			_ publicKey: UnsafeMutablePointer<CCRSACryptorRef?>,
+			_ privateKey: UnsafeMutablePointer<CCRSACryptorRef?>) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorGeneratePair: CCRSACryptorGeneratePairT? =
+			getFunc(CC.dl!, f: "CCRSACryptorGeneratePair")
 
-		private typealias CCRSACryptorReleaseT = @convention(c) (CCRSACryptorRef) -> Void
-		private static let CCRSACryptorRelease: CCRSACryptorReleaseT? =
-			getFunc(dl, f: "CCRSACryptorRelease")
+		fileprivate typealias CCRSACryptorReleaseT = @convention(c) (CCRSACryptorRef) -> Void
+		fileprivate static let CCRSACryptorRelease: CCRSACryptorReleaseT? =
+			getFunc(dl!, f: "CCRSACryptorRelease")
 
-		private typealias CCRSAGetKeyTypeT = @convention(c) (CCRSACryptorRef) -> CCRSAKeyType
-		private static let CCRSAGetKeyType: CCRSAGetKeyTypeT? = getFunc(dl, f: "CCRSAGetKeyType")
+		fileprivate typealias CCRSAGetKeyTypeT = @convention(c) (CCRSACryptorRef) -> CCRSAKeyType
+		fileprivate static let CCRSAGetKeyType: CCRSAGetKeyTypeT? = getFunc(dl!, f: "CCRSAGetKeyType")
 
-		private typealias CCRSAGetKeySizeT = @convention(c) (CCRSACryptorRef) -> Int32
-		private static let CCRSAGetKeySize: CCRSAGetKeySizeT? = getFunc(dl, f: "CCRSAGetKeySize")
+		fileprivate typealias CCRSAGetKeySizeT = @convention(c) (CCRSACryptorRef) -> Int32
+		fileprivate static let CCRSAGetKeySize: CCRSAGetKeySizeT? = getFunc(dl!, f: "CCRSAGetKeySize")
 
-		private typealias CCRSACryptorEncryptT = @convention(c) (
-			publicKey: CCRSACryptorRef,
-			padding: CCAsymmetricPadding,
-			plainText: UnsafePointer<Void>,
-			plainTextLen: Int,
-			cipherText: UnsafeMutablePointer<Void>,
-			cipherTextLen: UnsafeMutablePointer<Int>,
-			tagData: UnsafePointer<Void>,
-			tagDataLen: Int,
-			digestType: CCDigestAlgorithm) -> CCCryptorStatus
-		private static let CCRSACryptorEncrypt: CCRSACryptorEncryptT? =
-			getFunc(dl, f: "CCRSACryptorEncrypt")
+		fileprivate typealias CCRSACryptorEncryptT = @convention(c) (
+			_ publicKey: CCRSACryptorRef,
+			_ padding: CCAsymmetricPadding,
+			_ plainText: UnsafeRawPointer,
+			_ plainTextLen: Int,
+			_ cipherText: UnsafeMutableRawPointer,
+			_ cipherTextLen: UnsafeMutablePointer<Int>,
+			_ tagData: UnsafeRawPointer,
+			_ tagDataLen: Int,
+			_ digestType: CCDigestAlgorithm) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorEncrypt: CCRSACryptorEncryptT? =
+			getFunc(dl!, f: "CCRSACryptorEncrypt")
 
-		private typealias CCRSACryptorDecryptT = @convention (c) (
-			privateKey: CCRSACryptorRef,
-			padding: CCAsymmetricPadding,
-			cipherText: UnsafePointer<Void>,
-			cipherTextLen: Int,
-			plainText: UnsafeMutablePointer<Void>,
-			plainTextLen: UnsafeMutablePointer<Int>,
-			tagData: UnsafePointer<Void>,
-			tagDataLen: Int,
-			digestType: CCDigestAlgorithm) -> CCCryptorStatus
-		private static let CCRSACryptorDecrypt: CCRSACryptorDecryptT? =
-			getFunc(dl, f: "CCRSACryptorDecrypt")
+		fileprivate typealias CCRSACryptorDecryptT = @convention (c) (
+			_ privateKey: CCRSACryptorRef,
+			_ padding: CCAsymmetricPadding,
+			_ cipherText: UnsafeRawPointer,
+			_ cipherTextLen: Int,
+			_ plainText: UnsafeMutableRawPointer,
+			_ plainTextLen: UnsafeMutablePointer<Int>,
+			_ tagData: UnsafeRawPointer,
+			_ tagDataLen: Int,
+			_ digestType: CCDigestAlgorithm) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorDecrypt: CCRSACryptorDecryptT? =
+			getFunc(dl!, f: "CCRSACryptorDecrypt")
 
-		private typealias CCRSACryptorExportT = @convention(c) (
-			key: CCRSACryptorRef,
-			out: UnsafeMutablePointer<Void>,
-			outLen: UnsafeMutablePointer<Int>) -> CCCryptorStatus
-		private static let CCRSACryptorExport: CCRSACryptorExportT? =
-			getFunc(dl, f: "CCRSACryptorExport")
+		fileprivate typealias CCRSACryptorExportT = @convention(c) (
+			_ key: CCRSACryptorRef,
+			_ out: UnsafeMutableRawPointer,
+			_ outLen: UnsafeMutablePointer<Int>) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorExport: CCRSACryptorExportT? =
+			getFunc(dl!, f: "CCRSACryptorExport")
 
-		private typealias CCRSACryptorImportT = @convention(c) (
-			keyPackage: UnsafePointer<Void>,
-			keyPackageLen: Int,
-			key: UnsafeMutablePointer<CCRSACryptorRef>) -> CCCryptorStatus
-		private static let CCRSACryptorImport: CCRSACryptorImportT? =
-			getFunc(dl, f: "CCRSACryptorImport")
+		fileprivate typealias CCRSACryptorImportT = @convention(c) (
+			_ keyPackage: UnsafeRawPointer,
+			_ keyPackageLen: Int,
+			_ key: UnsafeMutablePointer<CCRSACryptorRef?>) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorImport: CCRSACryptorImportT? =
+			getFunc(dl!, f: "CCRSACryptorImport")
 
-		private typealias CCRSACryptorSignT = @convention(c) (
-			privateKey: CCRSACryptorRef,
-			padding: CCAsymmetricPadding,
-			hashToSign: UnsafePointer<Void>,
-			hashSignLen: size_t,
-			digestType: CCDigestAlgorithm,
-			saltLen: size_t,
-			signedData: UnsafeMutablePointer<Void>,
-			signedDataLen: UnsafeMutablePointer<Int>) -> CCCryptorStatus
-		private static let CCRSACryptorSign: CCRSACryptorSignT? =
-			getFunc(dl, f: "CCRSACryptorSign")
+		fileprivate typealias CCRSACryptorSignT = @convention(c) (
+			_ privateKey: CCRSACryptorRef,
+			_ padding: CCAsymmetricPadding,
+			_ hashToSign: UnsafeRawPointer,
+			_ hashSignLen: size_t,
+			_ digestType: CCDigestAlgorithm,
+			_ saltLen: size_t,
+			_ signedData: UnsafeMutableRawPointer,
+			_ signedDataLen: UnsafeMutablePointer<Int>) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorSign: CCRSACryptorSignT? =
+			getFunc(dl!, f: "CCRSACryptorSign")
 
-		private typealias CCRSACryptorVerifyT = @convention(c) (
-			publicKey: CCRSACryptorRef,
-			padding: CCAsymmetricPadding,
-			hash: UnsafePointer<Void>,
-			hashLen: size_t,
-			digestType: CCDigestAlgorithm,
-			saltLen: size_t,
-			signedData: UnsafePointer<Void>,
-			signedDataLen: size_t) -> CCCryptorStatus
-		private static let CCRSACryptorVerify: CCRSACryptorVerifyT? =
-			getFunc(dl, f: "CCRSACryptorVerify")
+		fileprivate typealias CCRSACryptorVerifyT = @convention(c) (
+			_ publicKey: CCRSACryptorRef,
+			_ padding: CCAsymmetricPadding,
+			_ hash: UnsafeRawPointer,
+			_ hashLen: size_t,
+			_ digestType: CCDigestAlgorithm,
+			_ saltLen: size_t,
+			_ signedData: UnsafeRawPointer,
+			_ signedDataLen: size_t) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorVerify: CCRSACryptorVerifyT? =
+			getFunc(dl!, f: "CCRSACryptorVerify")
 
-		private typealias CCRSACryptorCryptT = @convention(c) (
-			rsaKey: CCRSACryptorRef,
-			data: UnsafePointer<Void>, dataLength: size_t,
-			out: UnsafeMutablePointer<Void>,
-			outLength: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
-		private static let CCRSACryptorCrypt: CCRSACryptorCryptT? =
-			getFunc(dl, f: "CCRSACryptorCrypt")
+		fileprivate typealias CCRSACryptorCryptT = @convention(c) (
+			_ rsaKey: CCRSACryptorRef,
+			_ data: UnsafeRawPointer, _ dataLength: size_t,
+			_ out: UnsafeMutableRawPointer,
+			_ outLength: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
+		fileprivate static let CCRSACryptorCrypt: CCRSACryptorCryptT? =
+			getFunc(dl!, f: "CCRSACryptorCrypt")
 	}
 
-	public class DH {
+	open class DH {
 
 		public enum DHParam {
 			case rfc3526Group5
 		}
 
 		//this is stateful in CommonCrypto too, sry
-		public class DH {
-			private var ref: CCDHRef = nil
+		open class DH {
+			fileprivate var ref: CCDHRef? = nil
 
 			public init(dhParam: DHParam) throws {
-				ref = CCDHCreate!(dhParameter: kCCDHRFC3526Group5!)
+				ref = CCDHCreate!(kCCDHRFC3526Group5!)
 				guard ref != nil else {
 					throw CCError(.paramError)
 				}
 			}
 
-			public func generateKey() throws -> NSData {
+			open func generateKey() throws -> Data {
 				var outputLength = 8192
-				let output = NSMutableData(length: outputLength)!
-				let status = CCDHGenerateKey!(
-					ref: ref,
-					output: output.mutableBytes, outputLength: &outputLength)
-				output.length = outputLength
+				var output = Data(count: outputLength)
+                let status = output.withUnsafeMutableBytes { (outputBytes: UnsafeMutablePointer<UInt8>) -> CInt in
+                    return CCDHGenerateKey!(ref!, outputBytes, &outputLength)
+                }
+				output.count = outputLength
 				guard status != -1 else {
 					throw CCError(.paramError)
 				}
 				return output
 			}
 
-			public func computeKey(peerKey: NSData) throws -> NSData {
+			open func computeKey(_ peerKey: Data) throws -> Data {
 				var sharedKeyLength = 8192
-				let sharedKey = NSMutableData(length: sharedKeyLength)!
-				let status = CCDHComputeKey!(
-					sharedKey: sharedKey.mutableBytes, sharedKeyLen: &sharedKeyLength,
-					peerPubKey: peerKey.bytes, peerPubKeyLen: peerKey.length,
-					ref: ref)
-				sharedKey.length = sharedKeyLength
+				var sharedKey = Data(count: sharedKeyLength)
+                let status = sharedKey.withUnsafeMutableBytes { (sharedKeyBytes: UnsafeMutablePointer<UInt8>) -> CInt in
+                    return CCDHComputeKey!(
+                        sharedKeyBytes, &sharedKeyLength,
+                        (peerKey as NSData).bytes, peerKey.count,
+                        ref!)
+                }
+				sharedKey.count = sharedKeyLength
 				guard status == 0 else {
 					throw CCError(.paramError)
 				}
@@ -1504,148 +1541,156 @@ public class CC {
 
 			deinit {
 				if ref != nil {
-					CCDHRelease!(ref: ref)
+					CCDHRelease!(ref!)
 				}
 			}
 		}
 
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CCDHCreate != nil &&
 				CCDHRelease != nil &&
 				CCDHGenerateKey != nil &&
 				CCDHComputeKey != nil
 		}
 
-		private typealias CCDHParameters = UnsafePointer<Void>
-		private typealias CCDHRef = UnsafePointer<Void>
+		fileprivate typealias CCDHParameters = UnsafeRawPointer
+		fileprivate typealias CCDHRef = UnsafeRawPointer
 
-		private typealias kCCDHRFC3526Group5TM = UnsafePointer<CCDHParameters>
-		private static let kCCDHRFC3526Group5M: kCCDHRFC3526Group5TM? =
-			getFunc(dl, f: "kCCDHRFC3526Group5")
-		private static let kCCDHRFC3526Group5 = kCCDHRFC3526Group5M?.memory
+		fileprivate typealias kCCDHRFC3526Group5TM = UnsafePointer<CCDHParameters>
+		fileprivate static let kCCDHRFC3526Group5M: kCCDHRFC3526Group5TM? =
+			getFunc(dl!, f: "kCCDHRFC3526Group5")
+		fileprivate static let kCCDHRFC3526Group5 = kCCDHRFC3526Group5M?.pointee
 
-		private typealias CCDHCreateT = @convention(c) (
-			dhParameter: CCDHParameters) -> CCDHRef
-		private static let CCDHCreate: CCDHCreateT? = getFunc(dl, f: "CCDHCreate")
+		fileprivate typealias CCDHCreateT = @convention(c) (
+			_ dhParameter: CCDHParameters) -> CCDHRef
+		fileprivate static let CCDHCreate: CCDHCreateT? = getFunc(dl!, f: "CCDHCreate")
 
-		private typealias CCDHReleaseT = @convention(c) (
-			ref: CCDHRef) -> Void
-		private static let CCDHRelease: CCDHReleaseT? = getFunc(dl, f: "CCDHRelease")
+		fileprivate typealias CCDHReleaseT = @convention(c) (
+			_ ref: CCDHRef) -> Void
+		fileprivate static let CCDHRelease: CCDHReleaseT? = getFunc(dl!, f: "CCDHRelease")
 
-		private typealias CCDHGenerateKeyT = @convention(c) (
-			ref: CCDHRef,
-			output: UnsafeMutablePointer<Void>, outputLength: UnsafeMutablePointer<size_t>) -> CInt
-		private static let CCDHGenerateKey: CCDHGenerateKeyT? = getFunc(dl, f: "CCDHGenerateKey")
+		fileprivate typealias CCDHGenerateKeyT = @convention(c) (
+			_ ref: CCDHRef,
+			_ output: UnsafeMutableRawPointer, _ outputLength: UnsafeMutablePointer<size_t>) -> CInt
+		fileprivate static let CCDHGenerateKey: CCDHGenerateKeyT? = getFunc(dl!, f: "CCDHGenerateKey")
 
-		private typealias CCDHComputeKeyT = @convention(c) (
-			sharedKey: UnsafeMutablePointer<Void>, sharedKeyLen: UnsafeMutablePointer<size_t>,
-			peerPubKey: UnsafePointer<Void>, peerPubKeyLen: size_t,
-			ref: CCDHRef) -> CInt
-		private static let CCDHComputeKey: CCDHComputeKeyT? = getFunc(dl, f: "CCDHComputeKey")
+		fileprivate typealias CCDHComputeKeyT = @convention(c) (
+			_ sharedKey: UnsafeMutableRawPointer, _ sharedKeyLen: UnsafeMutablePointer<size_t>,
+			_ peerPubKey: UnsafeRawPointer, _ peerPubKeyLen: size_t,
+			_ ref: CCDHRef) -> CInt
+		fileprivate static let CCDHComputeKey: CCDHComputeKeyT? = getFunc(dl!, f: "CCDHComputeKey")
 	}
 
-	public class EC {
+	open class EC {
 
-		public static func generateKeyPair(keySize: Int) throws -> (NSData, NSData) {
-			var privKey: CCECCryptorRef = nil
-			var pubKey: CCECCryptorRef = nil
+		open static func generateKeyPair(_ keySize: Int) throws -> (Data, Data) {
+			var privKey: CCECCryptorRef? = nil
+			var pubKey: CCECCryptorRef? = nil
 			let status = CCECCryptorGeneratePair!(
-				keySize: keySize,
-				publicKey: &pubKey,
-				privateKey: &privKey)
+				keySize,
+				&pubKey,
+				&privKey)
 			guard status == noErr else { throw CCError(status) }
 
 			defer {
-				CCECCryptorRelease!(key: privKey)
-				CCECCryptorRelease!(key: pubKey)
+				CCECCryptorRelease!(privKey!)
+				CCECCryptorRelease!(pubKey!)
 			}
 
-			let privKeyDER = try exportKey(privKey, format: .importKeyBinary, type: .keyPrivate)
-			let pubKeyDER = try exportKey(pubKey, format: .importKeyBinary, type: .keyPublic)
+			let privKeyDER = try exportKey(privKey!, format: .importKeyBinary, type: .keyPrivate)
+			let pubKeyDER = try exportKey(pubKey!, format: .importKeyBinary, type: .keyPublic)
 			return (privKeyDER, pubKeyDER)
 		}
 
-		public static func signHash(privateKey: NSData, hash: NSData) throws -> NSData {
+		open static func signHash(_ privateKey: Data, hash: Data) throws -> Data {
 			let privKey = try importKey(privateKey, format: .importKeyBinary, keyType: .keyPrivate)
-			defer { CCECCryptorRelease!(key: privKey) }
+			defer { CCECCryptorRelease!(privKey) }
 
 			var signedDataLength = 4096
-			let signedData = NSMutableData(length:signedDataLength)!
-			let status = CCECCryptorSignHash!(
-				privateKey: privKey,
-				hashToSign: hash.bytes, hashSignLen: hash.length,
-				signedData: signedData.mutableBytes, signedDataLen: &signedDataLength)
+			var signedData = Data(count:signedDataLength)
+            let status = signedData.withUnsafeMutableBytes {
+                (signedDataBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCECCryptorSignHash!(
+                    privKey,
+                    (hash as NSData).bytes, hash.count,
+                    signedDataBytes, &signedDataLength)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			signedData.length = signedDataLength
+			signedData.count = signedDataLength
 			return signedData
 		}
 
-		public static func verifyHash(publicKey: NSData,
-		                              hash: NSData,
-		                              signedData: NSData) throws -> Bool {
+		open static func verifyHash(_ publicKey: Data,
+		                              hash: Data,
+		                              signedData: Data) throws -> Bool {
 			let pubKey = try importKey(publicKey, format: .importKeyBinary, keyType: .keyPublic)
-			defer { CCECCryptorRelease!(key: pubKey) }
+			defer { CCECCryptorRelease!(pubKey) }
 
 			var valid: UInt32 = 0
 			let status = CCECCryptorVerifyHash!(
-				publicKey:pubKey,
-				hash: hash.bytes, hashLen: hash.length,
-				signedData: signedData.bytes, signedDataLen: signedData.length,
-				valid: &valid)
+				pubKey,
+				(hash as NSData).bytes, hash.count,
+				(signedData as NSData).bytes, signedData.count,
+				&valid)
 			guard status == noErr else { throw CCError(status) }
 
 			return valid != 0
 		}
 
-		public static func computeSharedSecret(privateKey: NSData,
-		                                       publicKey: NSData) throws -> NSData {
+		open static func computeSharedSecret(_ privateKey: Data,
+		                                       publicKey: Data) throws -> Data {
 			let privKey = try importKey(privateKey, format: .importKeyBinary, keyType: .keyPrivate)
 			let pubKey = try importKey(publicKey, format: .importKeyBinary, keyType: .keyPublic)
 			defer {
-				CCECCryptorRelease!(key: privKey)
-				CCECCryptorRelease!(key: pubKey)
+				CCECCryptorRelease!(privKey)
+				CCECCryptorRelease!(pubKey)
 			}
 
 			var outSize = 8192
-			let result = NSMutableData(length:outSize)!
-			let status = CCECCryptorComputeSharedSecret!(
-				privateKey: privKey, publicKey: pubKey, out:result.mutableBytes, outLen:&outSize)
+			var result = Data(count:outSize)
+            let status = result.withUnsafeMutableBytes {
+                (resultBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCECCryptorComputeSharedSecret!(privKey, pubKey, resultBytes, &outSize)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			result.length = outSize
+			result.count = outSize
 			return result
 		}
 
-		private static func importKey(key: NSData, format: KeyExternalFormat,
+		fileprivate static func importKey(_ key: Data, format: KeyExternalFormat,
 		                              keyType: KeyType) throws -> CCECCryptorRef {
-			var impKey: CCECCryptorRef = nil
-			let status = CCECCryptorImportKey!(format: format.rawValue,
-			                                   keyPackage: key.bytes, keyPackageLen:key.length,
-			                                   keyType: keyType.rawValue, key: &impKey)
+			var impKey: CCECCryptorRef? = nil
+			let status = CCECCryptorImportKey!(format.rawValue,
+			                                   (key as NSData).bytes, key.count,
+			                                   keyType.rawValue, &impKey)
 			guard status == noErr else { throw CCError(status) }
 
-			return impKey
+			return impKey!
 		}
 
-		private static func exportKey(key: CCECCryptorRef, format: KeyExternalFormat,
-		                              type: KeyType) throws -> NSData {
+		fileprivate static func exportKey(_ key: CCECCryptorRef, format: KeyExternalFormat,
+		                              type: KeyType) throws -> Data {
 			var expKeyLength = 8192
-			let expKey = NSMutableData(length:expKeyLength)!
-			let status = CCECCryptorExportKey!(
-				format: format.rawValue,
-				keyPackage: expKey.mutableBytes,
-				keyPackageLen: &expKeyLength,
-				keyType: type.rawValue,
-				key: key)
+			var expKey = Data(count:expKeyLength)
+            let status = expKey.withUnsafeMutableBytes {
+                (expKeyBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCECCryptorExportKey!(
+                    format.rawValue,
+                    expKeyBytes,
+                    &expKeyLength,
+                    type.rawValue,
+                    key)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			expKey.length = expKeyLength
+			expKey.count = expKeyLength
 			return expKey
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CCECCryptorGeneratePair != nil &&
 				CCECCryptorImportKey != nil &&
 				CCECCryptorExportKey != nil &&
@@ -1655,73 +1700,73 @@ public class CC {
 				CCECCryptorComputeSharedSecret != nil
 		}
 
-		private enum KeyType: CCECKeyType {
+		fileprivate enum KeyType: CCECKeyType {
 			case keyPublic = 0, keyPrivate
 			case blankPublicKey = 97, blankPrivateKey
 			case badKey = 99
 		}
-		private typealias CCECKeyType = UInt32
+		fileprivate typealias CCECKeyType = UInt32
 
-		private typealias CCECKeyExternalFormat = UInt32
-		private enum KeyExternalFormat: CCECKeyExternalFormat {
+		fileprivate typealias CCECKeyExternalFormat = UInt32
+		fileprivate enum KeyExternalFormat: CCECKeyExternalFormat {
 			case importKeyBinary = 0, importKeyDER
 		}
 
-		private typealias CCECCryptorRef = UnsafePointer<Void>
-		private typealias CCECCryptorGeneratePairT = @convention(c) (
-			keySize: size_t ,
-			publicKey: UnsafeMutablePointer<CCECCryptorRef>,
-			privateKey: UnsafeMutablePointer<CCECCryptorRef>) -> CCCryptorStatus
-		private static let CCECCryptorGeneratePair: CCECCryptorGeneratePairT? =
-			getFunc(dl, f: "CCECCryptorGeneratePair")
+		fileprivate typealias CCECCryptorRef = UnsafeRawPointer
+		fileprivate typealias CCECCryptorGeneratePairT = @convention(c) (
+			_ keySize: size_t ,
+			_ publicKey: UnsafeMutablePointer<CCECCryptorRef?>,
+			_ privateKey: UnsafeMutablePointer<CCECCryptorRef?>) -> CCCryptorStatus
+		fileprivate static let CCECCryptorGeneratePair: CCECCryptorGeneratePairT? =
+			getFunc(dl!, f: "CCECCryptorGeneratePair")
 
-		private typealias CCECCryptorImportKeyT = @convention(c) (
-			format: CCECKeyExternalFormat,
-			keyPackage: UnsafePointer<Void>, keyPackageLen: size_t,
-			keyType: CCECKeyType, key: UnsafeMutablePointer<CCECCryptorRef>) -> CCCryptorStatus
-		private static let CCECCryptorImportKey: CCECCryptorImportKeyT? =
-			getFunc(dl, f: "CCECCryptorImportKey")
+		fileprivate typealias CCECCryptorImportKeyT = @convention(c) (
+			_ format: CCECKeyExternalFormat,
+			_ keyPackage: UnsafeRawPointer, _ keyPackageLen: size_t,
+			_ keyType: CCECKeyType, _ key: UnsafeMutablePointer<CCECCryptorRef?>) -> CCCryptorStatus
+		fileprivate static let CCECCryptorImportKey: CCECCryptorImportKeyT? =
+			getFunc(dl!, f: "CCECCryptorImportKey")
 
-		private typealias CCECCryptorExportKeyT = @convention(c) (
-			format: CCECKeyExternalFormat,
-			keyPackage: UnsafePointer<Void>,
-			keyPackageLen: UnsafePointer<size_t>,
-			keyType: CCECKeyType, key: CCECCryptorRef) -> CCCryptorStatus
-		private static let CCECCryptorExportKey: CCECCryptorExportKeyT? =
-			getFunc(dl, f: "CCECCryptorExportKey")
+		fileprivate typealias CCECCryptorExportKeyT = @convention(c) (
+			_ format: CCECKeyExternalFormat,
+			_ keyPackage: UnsafeRawPointer,
+			_ keyPackageLen: UnsafePointer<size_t>,
+			_ keyType: CCECKeyType, _ key: CCECCryptorRef) -> CCCryptorStatus
+		fileprivate static let CCECCryptorExportKey: CCECCryptorExportKeyT? =
+			getFunc(dl!, f: "CCECCryptorExportKey")
 
-		private typealias CCECCryptorReleaseT = @convention(c) (
-			key: CCECCryptorRef) -> Void
-		private static let CCECCryptorRelease: CCECCryptorReleaseT? =
-			getFunc(dl, f: "CCECCryptorRelease")
+		fileprivate typealias CCECCryptorReleaseT = @convention(c) (
+			_ key: CCECCryptorRef) -> Void
+		fileprivate static let CCECCryptorRelease: CCECCryptorReleaseT? =
+			getFunc(dl!, f: "CCECCryptorRelease")
 
-		private typealias CCECCryptorSignHashT = @convention(c)(
-			privateKey: CCECCryptorRef,
-			hashToSign: UnsafePointer<Void>,
-			hashSignLen: size_t,
-			signedData: UnsafeMutablePointer<Void>,
-			signedDataLen: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
-		private static let CCECCryptorSignHash: CCECCryptorSignHashT? =
-			getFunc(dl, f: "CCECCryptorSignHash")
+		fileprivate typealias CCECCryptorSignHashT = @convention(c)(
+			_ privateKey: CCECCryptorRef,
+			_ hashToSign: UnsafeRawPointer,
+			_ hashSignLen: size_t,
+			_ signedData: UnsafeMutableRawPointer,
+			_ signedDataLen: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
+		fileprivate static let CCECCryptorSignHash: CCECCryptorSignHashT? =
+			getFunc(dl!, f: "CCECCryptorSignHash")
 
-		private typealias CCECCryptorVerifyHashT = @convention(c)(
-			publicKey: CCECCryptorRef,
-			hash: UnsafePointer<Void>, hashLen: size_t,
-			signedData: UnsafePointer<Void>, signedDataLen: size_t,
-			valid: UnsafeMutablePointer<UInt32>) -> CCCryptorStatus
-		private static let CCECCryptorVerifyHash: CCECCryptorVerifyHashT? =
-			getFunc(dl, f: "CCECCryptorVerifyHash")
+		fileprivate typealias CCECCryptorVerifyHashT = @convention(c)(
+			_ publicKey: CCECCryptorRef,
+			_ hash: UnsafeRawPointer, _ hashLen: size_t,
+			_ signedData: UnsafeRawPointer, _ signedDataLen: size_t,
+			_ valid: UnsafeMutablePointer<UInt32>) -> CCCryptorStatus
+		fileprivate static let CCECCryptorVerifyHash: CCECCryptorVerifyHashT? =
+			getFunc(dl!, f: "CCECCryptorVerifyHash")
 
-		private typealias CCECCryptorComputeSharedSecretT = @convention(c)(
-			privateKey: CCECCryptorRef,
-			publicKey: CCECCryptorRef,
-			out: UnsafeMutablePointer<Void>,
-			outLen: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
-		private static let CCECCryptorComputeSharedSecret: CCECCryptorComputeSharedSecretT? =
-			getFunc(dl, f: "CCECCryptorComputeSharedSecret")
+		fileprivate typealias CCECCryptorComputeSharedSecretT = @convention(c)(
+			_ privateKey: CCECCryptorRef,
+			_ publicKey: CCECCryptorRef,
+			_ out: UnsafeMutableRawPointer,
+			_ outLen: UnsafeMutablePointer<size_t>) -> CCCryptorStatus
+		fileprivate static let CCECCryptorComputeSharedSecret: CCECCryptorComputeSharedSecretT? =
+			getFunc(dl!, f: "CCECCryptorComputeSharedSecret")
 	}
 
-	public class CRC {
+	open class CRC {
 
 		public typealias CNcrc = UInt32
 		public enum Mode: CNcrc {
@@ -1752,51 +1797,53 @@ public class CC {
 			crc64ECMA182 = 60
 		}
 
-		public static func crc(input: NSData, mode: Mode) throws -> UInt64 {
+		open static func crc(_ input: Data, mode: Mode) throws -> UInt64 {
 			var result: UInt64 = 0
 			let status = CNCRC!(
-				algorithm: mode.rawValue,
-				input: input.bytes, inputLen: input.length,
-				result: &result)
+				mode.rawValue,
+				(input as NSData).bytes, input.count,
+				&result)
 			guard status == noErr else {
 				throw CCError(status)
 			}
 			return result
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CNCRC != nil
 		}
 
-		private typealias CNCRCT = @convention(c) (
-			algorithm: CNcrc,
-			input: UnsafePointer<Void>, inputLen: size_t,
-			result: UnsafeMutablePointer<UInt64>) -> CCCryptorStatus
-		private static let CNCRC: CNCRCT? = getFunc(dl, f: "CNCRC")
+		fileprivate typealias CNCRCT = @convention(c) (
+			_ algorithm: CNcrc,
+			_ input: UnsafeRawPointer, _ inputLen: size_t,
+			_ result: UnsafeMutablePointer<UInt64>) -> CCCryptorStatus
+		fileprivate static let CNCRC: CNCRCT? = getFunc(dl!, f: "CNCRC")
 	}
 
-	public class CMAC {
+	open class CMAC {
 
-		public static func AESCMAC(data: NSData, key: NSData) -> NSData {
-			let result = NSMutableData(length: 16)!
-			CCAESCmac!(key: key.bytes,
-			           data: data.bytes, dataLen: data.length,
-			           macOut: result.mutableBytes)
+		open static func AESCMAC(_ data: Data, key: Data) -> Data {
+			var result = Data(count: 16)
+            result.withUnsafeMutableBytes { (resultBytes: UnsafeMutablePointer<UInt8>) -> Void in
+                CCAESCmac!((key as NSData).bytes,
+                           (data as NSData).bytes, data.count,
+                           resultBytes)
+            }
 			return result
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CCAESCmac != nil
 		}
 
-		private typealias CCAESCmacT = @convention(c) (
-			key: UnsafePointer<Void>,
-			data: UnsafePointer<Void>, dataLen: size_t,
-			macOut: UnsafeMutablePointer<Void>) -> Void
-		private static let CCAESCmac: CCAESCmacT? = getFunc(dl, f: "CCAESCmac")
+		fileprivate typealias CCAESCmacT = @convention(c) (
+			_ key: UnsafeRawPointer,
+			_ data: UnsafeRawPointer, _ dataLen: size_t,
+			_ macOut: UnsafeMutableRawPointer) -> Void
+		fileprivate static let CCAESCmac: CCAESCmacT? = getFunc(dl!, f: "CCAESCmac")
 	}
 
-	public class KeyDerivation {
+	open class KeyDerivation {
 
 		public typealias CCPseudoRandomAlgorithm = UInt32
 		public enum PRFAlg: CCPseudoRandomAlgorithm {
@@ -1812,216 +1859,236 @@ public class CC {
 			}
 		}
 
-		public static func PBKDF2(password: String, salt: NSData,
-		                         prf: PRFAlg, rounds: UInt32) throws -> NSData {
+		open static func PBKDF2(_ password: String, salt: Data,
+		                         prf: PRFAlg, rounds: UInt32) throws -> Data {
 
-			let result = NSMutableData(length:prf.cc.digestLength)!
-			let passwData = password.dataUsingEncoding(NSUTF8StringEncoding)!
-			let status = CCKeyDerivationPBKDF!(algorithm: PBKDFAlgorithm.pbkdf2.rawValue,
-			                      password: passwData.bytes, passwordLen: passwData.length,
-			                      salt: salt.bytes, saltLen: salt.length,
-			                      prf: prf.rawValue, rounds: rounds,
-			                      derivedKey: result.mutableBytes, derivedKeyLen: result.length)
+			var result = Data(count:prf.cc.digestLength)
+			let passwData = password.data(using: String.Encoding.utf8)!
+            let status = result.withUnsafeMutableBytes {
+                (passwDataBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCKeyDerivationPBKDF!(PBKDFAlgorithm.pbkdf2.rawValue,
+                                             (passwData as NSData).bytes, passwData.count,
+                                             (salt as NSData).bytes, salt.count,
+                                             prf.rawValue, rounds,
+                                             passwDataBytes, result.count)
+            }
 			guard status == noErr else { throw CCError(status) }
 
 			return result
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CCKeyDerivationPBKDF != nil
 		}
 
-		private typealias CCPBKDFAlgorithm = UInt32
-		private enum PBKDFAlgorithm: CCPBKDFAlgorithm {
+		fileprivate typealias CCPBKDFAlgorithm = UInt32
+		fileprivate enum PBKDFAlgorithm: CCPBKDFAlgorithm {
 			case pbkdf2 = 2
 		}
 
-		private typealias CCKeyDerivationPBKDFT = @convention(c) (
-			algorithm: CCPBKDFAlgorithm,
-			password: UnsafePointer<Void>, passwordLen: size_t,
-			salt: UnsafePointer<Void>, saltLen: size_t,
-			prf: CCPseudoRandomAlgorithm, rounds: uint,
-			derivedKey: UnsafeMutablePointer<Void>, derivedKeyLen: size_t) -> CCCryptorStatus
-		private static let CCKeyDerivationPBKDF: CCKeyDerivationPBKDFT? =
-			getFunc(dl, f: "CCKeyDerivationPBKDF")
+		fileprivate typealias CCKeyDerivationPBKDFT = @convention(c) (
+			_ algorithm: CCPBKDFAlgorithm,
+			_ password: UnsafeRawPointer, _ passwordLen: size_t,
+			_ salt: UnsafeRawPointer, _ saltLen: size_t,
+			_ prf: CCPseudoRandomAlgorithm, _ rounds: uint,
+			_ derivedKey: UnsafeMutableRawPointer, _ derivedKeyLen: size_t) -> CCCryptorStatus
+		fileprivate static let CCKeyDerivationPBKDF: CCKeyDerivationPBKDFT? =
+			getFunc(dl!, f: "CCKeyDerivationPBKDF")
 	}
 
-	public class KeyWrap {
+	open class KeyWrap {
 
-		private static let rfc3394IVData: [UInt8] = [0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6]
-		public static let rfc3394IV = NSData(bytes: rfc3394IVData, length:rfc3394IVData.count)
+		fileprivate static let rfc3394IVData: [UInt8] = [0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6]
+		open static let rfc3394IV = Data(bytes: UnsafePointer<UInt8>(rfc3394IVData), count:rfc3394IVData.count)
 
-		public static func SymmetricKeyWrap(iv: NSData,
-		                                    kek: NSData,
-		                                    rawKey: NSData) throws -> NSData {
+		open static func SymmetricKeyWrap(_ iv: Data,
+		                                    kek: Data,
+		                                    rawKey: Data) throws -> Data {
 			let alg = WrapAlg.aes.rawValue
-			var wrappedKeyLength = CCSymmetricWrappedSize!(algorithm: alg, rawKeyLen: rawKey.length)
-			let wrappedKey = NSMutableData(length:wrappedKeyLength)!
-			let status = CCSymmetricKeyWrap!(
-				algorithm: alg,
-				iv: iv.bytes, ivLen: iv.length,
-				kek: kek.bytes, kekLen: kek.length,
-				rawKey: rawKey.bytes, rawKeyLen: rawKey.length,
-				wrappedKey: wrappedKey.mutableBytes, wrappedKeyLen:&wrappedKeyLength)
+			var wrappedKeyLength = CCSymmetricWrappedSize!(alg, rawKey.count)
+			var wrappedKey = Data(count:wrappedKeyLength)
+            let status = wrappedKey.withUnsafeMutableBytes {
+                (wrappedKeyBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCSymmetricKeyWrap!(
+                    alg,
+                    (iv as NSData).bytes, iv.count,
+                    (kek as NSData).bytes, kek.count,
+                    (rawKey as NSData).bytes, rawKey.count,
+                    wrappedKeyBytes, &wrappedKeyLength)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			wrappedKey.length = wrappedKeyLength
+			wrappedKey.count = wrappedKeyLength
 			return wrappedKey
 		}
 
-		public static func SymmetricKeyUnwrap(iv: NSData,
-		                                      kek: NSData,
-		                                      wrappedKey: NSData) throws -> NSData {
+		open static func SymmetricKeyUnwrap(_ iv: Data,
+		                                      kek: Data,
+		                                      wrappedKey: Data) throws -> Data {
 			let alg = WrapAlg.aes.rawValue
-			var rawKeyLength = CCSymmetricUnwrappedSize!(algorithm: alg, wrappedKeyLen: wrappedKey.length)
-			let rawKey = NSMutableData(length:rawKeyLength)!
-			let status = CCSymmetricKeyUnwrap!(
-				algorithm: alg,
-				iv: iv.bytes, ivLen: iv.length,
-				kek: kek.bytes, kekLen: kek.length,
-				wrappedKey: wrappedKey.bytes, wrappedKeyLen: wrappedKey.length,
-				rawKey: rawKey.mutableBytes, rawKeyLen:&rawKeyLength)
+			var rawKeyLength = CCSymmetricUnwrappedSize!(alg, wrappedKey.count)
+			var rawKey = Data(count:rawKeyLength)
+            let status = rawKey.withUnsafeMutableBytes {
+                (rawKeyBytes: UnsafeMutablePointer<UInt8>) -> CCCryptorStatus in
+                return CCSymmetricKeyUnwrap!(
+                    alg,
+                    (iv as NSData).bytes, iv.count,
+                    (kek as NSData).bytes, kek.count,
+                    (wrappedKey as NSData).bytes, wrappedKey.count,
+                    rawKeyBytes, &rawKeyLength)
+            }
 			guard status == noErr else { throw CCError(status) }
 
-			rawKey.length = rawKeyLength
+			rawKey.count = rawKeyLength
 			return rawKey
 		}
 
-		public static func available() -> Bool {
+		open static func available() -> Bool {
 			return CCSymmetricKeyWrap != nil &&
 				CCSymmetricKeyUnwrap != nil &&
 				CCSymmetricWrappedSize != nil &&
 				CCSymmetricUnwrappedSize != nil
 		}
 
-		private enum WrapAlg: CCWrappingAlgorithm {
+		fileprivate enum WrapAlg: CCWrappingAlgorithm {
 			case aes = 1
 		}
-		private typealias CCWrappingAlgorithm = UInt32
+		fileprivate typealias CCWrappingAlgorithm = UInt32
 
-		private typealias CCSymmetricKeyWrapT = @convention(c) (
-			algorithm: CCWrappingAlgorithm,
-			iv: UnsafePointer<Void>, ivLen: size_t,
-			kek: UnsafePointer<Void>, kekLen: size_t,
-			rawKey: UnsafePointer<Void>, rawKeyLen: size_t,
-			wrappedKey: UnsafeMutablePointer<Void>,
-			wrappedKeyLen: UnsafePointer<size_t>) -> CCCryptorStatus
-		private static let CCSymmetricKeyWrap: CCSymmetricKeyWrapT? = getFunc(dl, f: "CCSymmetricKeyWrap")
+		fileprivate typealias CCSymmetricKeyWrapT = @convention(c) (
+			_ algorithm: CCWrappingAlgorithm,
+			_ iv: UnsafeRawPointer, _ ivLen: size_t,
+			_ kek: UnsafeRawPointer, _ kekLen: size_t,
+			_ rawKey: UnsafeRawPointer, _ rawKeyLen: size_t,
+			_ wrappedKey: UnsafeMutableRawPointer,
+			_ wrappedKeyLen: UnsafePointer<size_t>) -> CCCryptorStatus
+		fileprivate static let CCSymmetricKeyWrap: CCSymmetricKeyWrapT? = getFunc(dl!, f: "CCSymmetricKeyWrap")
 
-		private typealias CCSymmetricKeyUnwrapT = @convention(c) (
-			algorithm: CCWrappingAlgorithm,
-			iv: UnsafePointer<Void>, ivLen: size_t,
-			kek: UnsafePointer<Void>, kekLen: size_t,
-			wrappedKey: UnsafePointer<Void>, wrappedKeyLen: size_t,
-			rawKey: UnsafeMutablePointer<Void>,
-			rawKeyLen: UnsafePointer<size_t>) -> CCCryptorStatus
-		private static let CCSymmetricKeyUnwrap: CCSymmetricKeyUnwrapT? =
-			getFunc(dl, f: "CCSymmetricKeyUnwrap")
+		fileprivate typealias CCSymmetricKeyUnwrapT = @convention(c) (
+			_ algorithm: CCWrappingAlgorithm,
+			_ iv: UnsafeRawPointer, _ ivLen: size_t,
+			_ kek: UnsafeRawPointer, _ kekLen: size_t,
+			_ wrappedKey: UnsafeRawPointer, _ wrappedKeyLen: size_t,
+			_ rawKey: UnsafeMutableRawPointer,
+			_ rawKeyLen: UnsafePointer<size_t>) -> CCCryptorStatus
+		fileprivate static let CCSymmetricKeyUnwrap: CCSymmetricKeyUnwrapT? =
+			getFunc(dl!, f: "CCSymmetricKeyUnwrap")
 
-		private typealias CCSymmetricWrappedSizeT = @convention(c) (
-			algorithm: CCWrappingAlgorithm,
-			rawKeyLen: size_t) -> size_t
-		private static let CCSymmetricWrappedSize: CCSymmetricWrappedSizeT? =
-			getFunc(dl, f: "CCSymmetricWrappedSize")
+		fileprivate typealias CCSymmetricWrappedSizeT = @convention(c) (
+			_ algorithm: CCWrappingAlgorithm,
+			_ rawKeyLen: size_t) -> size_t
+		fileprivate static let CCSymmetricWrappedSize: CCSymmetricWrappedSizeT? =
+			getFunc(dl!, f: "CCSymmetricWrappedSize")
 
-		private typealias CCSymmetricUnwrappedSizeT = @convention(c) (
-			algorithm: CCWrappingAlgorithm,
-			wrappedKeyLen: size_t) -> size_t
-		private static let CCSymmetricUnwrappedSize: CCSymmetricUnwrappedSizeT? =
-			getFunc(dl, f: "CCSymmetricUnwrappedSize")
+		fileprivate typealias CCSymmetricUnwrappedSizeT = @convention(c) (
+			_ algorithm: CCWrappingAlgorithm,
+			_ wrappedKeyLen: size_t) -> size_t
+		fileprivate static let CCSymmetricUnwrappedSize: CCSymmetricUnwrappedSizeT? =
+			getFunc(dl!, f: "CCSymmetricUnwrappedSize")
 
 	}
 
 }
 
-private func getFunc<T>(from: UnsafeMutablePointer<Void>, f: String) -> T? {
+private func getFunc<T>(_ from: UnsafeMutableRawPointer, f: String) -> T? {
 	let sym = dlsym(from, f)
 	guard sym != nil else {
 		return nil
 	}
-	return unsafeBitCast(sym, T.self)
+	return unsafeBitCast(sym, to: T.self)
 }
 
-extension NSData {
-	/// Create hexadecimal string representation of NSData object.
+extension Data {
+	/// Create hexadecimal string representation of Data object.
 	///
-	/// - returns: String representation of this NSData object.
+	/// - returns: String representation of this Data object.
 
 	public func hexadecimalString() -> String {
 		var hexstr = String()
-		for i in UnsafeBufferPointer<UInt8>(start: UnsafeMutablePointer<UInt8>(bytes), count: length) {
-			hexstr += String(format: "%02X", i)
-		}
+        self.withUnsafeBytes { (data: UnsafePointer<UInt8>) -> Void in
+            for i in UnsafeBufferPointer<UInt8>(start: data, count: count) {
+                hexstr += String(format: "%02X", i)
+            }
+        }
 		return hexstr
 	}
 
 	public func arrayOfBytes() -> [UInt8] {
-		let count = self.length / sizeof(UInt8)
-		var bytesArray = [UInt8](count: count, repeatedValue: 0)
-		self.getBytes(&bytesArray, length:count * sizeof(UInt8))
+		let count = self.count / MemoryLayout<UInt8>.size
+		var bytesArray = [UInt8](repeating: 0, count: count)
+		(self as NSData).getBytes(&bytesArray, length:count * MemoryLayout<UInt8>.size)
 		return bytesArray
 	}
 
-	private var bytesView: BytesView { return BytesView(self) }
+	fileprivate var bytesView: BytesView { return BytesView(self) }
 
-	private func bytesViewRange(range: NSRange) -> BytesView {
+	fileprivate func bytesViewRange(_ range: NSRange) -> BytesView {
 		return BytesView(self, range: range)
 	}
 
-	private struct BytesView: CollectionType {
-		// The view retains the NSData. That's on purpose.
-		// NSData doesn't retain the view, so there's no loop.
-		let data: NSData
-		init(_ data: NSData) {
+	fileprivate struct BytesView: Collection {
+		// The view retains the Data. That's on purpose.
+		// Data doesn't retain the view, so there's no loop.
+		let data: Data
+		init(_ data: Data) {
 			self.data = data
 			self.startIndex = 0
-			self.endIndex = data.length
+			self.endIndex = data.count
 		}
 
-		init(_ data: NSData, range: NSRange ) {
+		init(_ data: Data, range: NSRange ) {
 			self.data = data
 			self.startIndex = range.location
 			self.endIndex = range.location + range.length
 		}
 
 		subscript (position: Int) -> UInt8 {
-			return UnsafePointer<UInt8>(data.bytes)[position]
+            var value: UInt8 = 0
+            data.withUnsafeBytes { (dataBytes: UnsafePointer<UInt8>) -> Void in
+                value = UnsafeBufferPointer<UInt8>(start: dataBytes, count: data.count)[position]
+            }
+            return value
 		}
-		subscript (bounds: Range<Int>) -> NSData {
-			return data.subdataWithRange(NSRange(bounds))
+		subscript (bounds: Range<Int>) -> Data {
+			return data.subdata(in: bounds)
 		}
+        fileprivate func formIndex(after i: inout Int) {
+            i += 1
+        }
+        fileprivate func index(after i: Int) -> Int {
+            return i + 1
+        }
 		var startIndex: Int
 		var endIndex: Int
 		var length: Int { return endIndex - startIndex }
 	}
 }
 
-extension String.CharacterView.Index : Strideable { }
 extension String {
 
-	/// Create NSData from hexadecimal string representation
+	/// Create Data from hexadecimal string representation
 	///
-	/// This takes a hexadecimal representation and creates a NSData object. Note, if the string has
+	/// This takes a hexadecimal representation and creates a Data object. Note, if the string has
 	/// any spaces, those are removed. Also if the string started with a '<' or ended with a '>',
 	/// those are removed, too. This does no validation of the string to ensure it's a valid
 	/// hexadecimal string
 	///
 	/// The use of `strtoul` inspired by Martin R at http://stackoverflow.com/a/26284562/1271826
 	///
-	/// - returns: NSData represented by this hexadecimal string.
+	/// - returns: Data represented by this hexadecimal string.
 	///            Returns nil if string contains characters outside the 0-9 and a-f range.
 
-	public func dataFromHexadecimalString() -> NSData? {
-		let trimmedString = self.stringByTrimmingCharactersInSet(
-			NSCharacterSet(charactersInString: "<> ")).stringByReplacingOccurrencesOfString(
-				" ", withString: "")
+	public func dataFromHexadecimalString() -> Data? {
+		let trimmedString = self.trimmingCharacters(
+			in: CharacterSet(charactersIn: "<> ")).replacingOccurrences(
+				of: " ", with: "")
 
 		// make sure the cleaned up string consists solely of hex digits,
 		// and that we have even number of them
 
-		let regex = try! NSRegularExpression(pattern: "^[0-9a-f]*$", options: .CaseInsensitive)
+		let regex = try! NSRegularExpression(pattern: "^[0-9a-f]*$", options: .caseInsensitive)
 
-		let found = regex.firstMatchInString(trimmedString, options: [],
+		let found = regex.firstMatch(in: trimmedString, options: [],
 		                                     range: NSRange(location: 0,
 												length: trimmedString.characters.count))
 		guard found != nil &&
@@ -2030,15 +2097,19 @@ extension String {
 				return nil
 		}
 
-		// everything ok, so now let's build NSData
+		// everything ok, so now let's build Data
 
-		let data = NSMutableData(capacity: trimmedString.characters.count / 2)
-
-		for index in trimmedString.startIndex.stride(to:trimmedString.endIndex, by:2) {
-			let byteString = trimmedString.substringWithRange(index..<index.successor().successor())
-			let num = UInt8(byteString.withCString { strtoul($0, nil, 16) })
-			data?.appendBytes([num] as [UInt8], length: 1)
-		}
+		var data = Data(capacity: trimmedString.characters.count / 2)
+        var index: String.Index? = trimmedString.startIndex
+        
+        while let i = index {
+            let byteString = trimmedString.substring(with: i ..< trimmedString.index(i, offsetBy: 2))
+            let num = UInt8(byteString.withCString { strtoul($0, nil, 16) })
+            data.append([num] as [UInt8], count: 1)
+            
+            index = trimmedString.index(i, offsetBy: 2, limitedBy: trimmedString.endIndex)
+            if index == trimmedString.endIndex { break }
+        }
 
 		return data
 	}


### PR DESCRIPTION
Tests pass, except `testUpsert` and `testDel`. They fail on my machine: function `SecItemAdd` inside of `SwKeyStore.upsertKey` method returns status `-34018`. This happens before and after migration.