### PR TITLE
Xcode 10.2/Swift 5 fix

### DIFF
--- a/SwCrypt/SwCrypt.swift
+++ b/SwCrypt/SwCrypt.swift
@@ -1346,7 +1346,7 @@ open class CC {
 
 			let zeroBits = 8 * emLength - emBits
 			maskedDB.withUnsafeMutableBytes { maskedDBBytes in
-				maskedDBBytes[0] &= UInt8(0xff >> zeroBits)
+				maskedDBBytes[0] &= 0xff >> UInt8(zeroBits)
 			}
 
 			var ret = maskedDB
@@ -1392,7 +1392,7 @@ open class CC {
 			let dbMask = mgf1(digest, seed: mPrimeHash, maskLength: emLength - hash.count - 1)
 			var db = xorData(maskedDB, dbMask)
 			db.withUnsafeMutableBytes { dbBytes in
-				dbBytes[0] &= UInt8(0xff >> zeroBits)
+				dbBytes[0] &= 0xff >> UInt8(zeroBits)
 			}
 
 			let zeroLength = emLength - hash.count - saltLength - 2


### PR DESCRIPTION
Removes '0xff' from the UInt8 initializer.