### PR TITLE
Fix for Xcode 10.2/Swift 5.0 build

### DIFF
--- a/SwCrypt/SwCrypt.swift
+++ b/SwCrypt/SwCrypt.swift
@@ -1346,7 +1346,8 @@ open class CC {
 
 			let zeroBits = 8 * emLength - emBits
 			maskedDB.withUnsafeMutableBytes { maskedDBBytes in
-				maskedDBBytes[0] &= UInt8(0xff >> zeroBits)
+				let shifted = 0xff >> zeroBits
+				maskedDBBytes[0] &= UInt8(shifted)
 			}
 
 			var ret = maskedDB
@@ -1392,7 +1393,8 @@ open class CC {
 			let dbMask = mgf1(digest, seed: mPrimeHash, maskLength: emLength - hash.count - 1)
 			var db = xorData(maskedDB, dbMask)
 			db.withUnsafeMutableBytes { dbBytes in
-				dbBytes[0] &= UInt8(0xff >> zeroBits)
+				let shifted = 0xff >> zeroBits
+				dbBytes[0] &= UInt8(shifted)
 			}
 
 			let zeroLength = emLength - hash.count - saltLength - 2


### PR DESCRIPTION
Moving bitwise shift outside of helps to avoid build error in Xcode 10.2