### PR TITLE
kCCModeOptionCTR_BE needed when using CTR block mode

### DIFF
--- a/SwCrypt/SwCrypt.swift
+++ b/SwCrypt/SwCrypt.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CommonCrypto
 
 open class SwKeyStore {
 
@@ -724,7 +725,7 @@ open class CC {
 
 	public static func crypt(_ opMode: OpMode, blockMode: BlockMode,
 							algorithm: Algorithm, padding: Padding,
-							data: Data, key: Data, iv: Data) throws -> Data {
+							data: Data, key: Data, iv: Data, options: Int = kCCModeOptionCTR_BE) throws -> Data {
 		if blockMode.needIV {
 			guard iv.count == algorithm.blockSize else { throw CCError(.paramError) }
 		}
@@ -736,7 +737,7 @@ open class CC {
 				algorithm.rawValue, padding.rawValue,
 				ivBytes, keyBytes, key.count,
 				nil, 0, 0,
-				CCModeOptions(), &cryptor)
+				CCModeOptions(options), &cryptor)
 		})
 
 		guard status == noErr else { throw CCError(status) }


### PR DESCRIPTION
Hi, 

I added default argument options: Int = kCCModeOptionCTR_BE respective code change in crypt function to ensure proper CTR block-mode operation, as that mode was not working properly without that option being set. 

For Xcode to recognize kCCModeOptionCTR_BE, it was necessary to import CommonCrypto.  