### PR TITLE
Add / strip header to / from public PEM

### DIFF
--- a/SwCrypt/SwCrypt.swift
+++ b/SwCrypt/SwCrypt.swift
@@ -436,11 +436,11 @@ open class PEM {
 		fileprivate static let pemPrefix = "-----BEGIN PUBLIC KEY-----\n"
 		fileprivate static let pemSuffix = "\n-----END PUBLIC KEY-----"
 
-		fileprivate static func addHeader(_ base64: String) -> String {
+		public static func addHeader(_ base64: String) -> String {
 			return pemPrefix + base64 + pemSuffix
 		}
 
-		fileprivate static func stripHeader(_ pemKey: String) -> String? {
+		public static func stripHeader(_ pemKey: String) -> String? {
 			return PEM.stripHeaderFooter(pemKey, header: pemPrefix, footer: pemSuffix)
 		}
 	}


### PR DESCRIPTION
String representation of Android RSA keys does not make use of standard PEM headers. In order to simplify export / import of public keys to / from Android, PEM headers should be made optional. A first step is opening up the add / strip header functions.