### PR TITLE
Add support for PKCS8 private key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ let (privateKey, publicKey) = try! CC.RSA.generateKeyPair(2048)
 ### Convert them to PEM format
 ```
 let privateKeyPEM = try SwKeyConvert.PrivateKey.derToPKCS1PEM(privateKey)
+let privateKeyPEMPKCS8 = try SwKeyConvert.PrivateKey.derToPKCS8PEM(privateKey)
 let publicKeyPEM = SwKeyConvert.PublicKey.derToPKCS8PEM(publicKey)
 ```
 ### Or read them from strings with PEM data

--- a/SwCryptTests/SwCryptTests.swift
+++ b/SwCryptTests/SwCryptTests.swift
@@ -135,6 +135,17 @@ class SwCryptTest: XCTestCase {
 			XCTAssert($0 as? SwKeyConvert.SwError == SwKeyConvert.SwError.badPassphrase)
 		}
 	}
+    
+    func testPKCS8KeyPair() {
+        let (priv, pub) = keyPair!
+        
+        let privKeyPem = SwKeyConvert.PrivateKey.derToPKCS8PEM(priv)
+        
+        let privKey = try? SwKeyConvert.PrivateKey.pemToPKCS1DER(privKeyPem)
+        let genPubKey = try? CC.RSA.getPublicKeyFromPrivateKey(privKey!)
+        
+        XCTAssert(pub == genPubKey)
+    }
 
 	func testOpenSSLKeyPair() {
 		let bundle = Bundle(for: type(of: self))


### PR DESCRIPTION
Fixes #68 given the `WebCrypto` API expects private keys in PKCS8 format.